### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   - push
   - pull_request
+permissions:
+  contents: read
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}


### PR DESCRIPTION
Potential fix for [https://github.com/cossio/RestrictedBoltzmannMachines.jl/security/code-scanning/2](https://github.com/cossio/RestrictedBoltzmannMachines.jl/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (top level), so it applies to all jobs unless overridden. For this CI pipeline, the minimal safe baseline is:

- `contents: read`

This preserves existing functionality (checkout and test steps) while enforcing least privilege for `GITHUB_TOKEN`.  
Edit the file near the top, after the `on` triggers and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
