### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ on:
     tags: [v*]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cossio/RestrictedBoltzmannMachines.jl/security/code-scanning/1](https://github.com/cossio/RestrictedBoltzmannMachines.jl/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/docs.yml` so the `GITHUB_TOKEN` is scoped intentionally.  
Best single fix here: define permissions at the workflow root (applies to all jobs unless overridden), with at least `contents: read` per CodeQL guidance. This resolves the alert and preserves existing behavior as much as possible given the provided snippet.

Concretely, insert:

```yml
permissions:
  contents: read
```

between the `on:` triggers and `jobs:` section (after line 8 in the provided snippet).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
