### PR TITLE
Add HDF5 support for ReLU-family layers and CenteredRBM

### DIFF
--- a/ext/HDF5Ext.jl
+++ b/ext/HDF5Ext.jl
@@ -4,12 +4,16 @@ import HDF5
 import RestrictedBoltzmannMachines
 using HDF5: h5open
 using RestrictedBoltzmannMachines: Binary
+using RestrictedBoltzmannMachines: CenteredRBM
 using RestrictedBoltzmannMachines: Gaussian
 using RestrictedBoltzmannMachines: Potts
 using RestrictedBoltzmannMachines: PottsGumbel
 using RestrictedBoltzmannMachines: RBM
+using RestrictedBoltzmannMachines: ReLU
 using RestrictedBoltzmannMachines: Spin
 using RestrictedBoltzmannMachines: StandardizedRBM
+using RestrictedBoltzmannMachines: dReLU
+using RestrictedBoltzmannMachines: pReLU
 using RestrictedBoltzmannMachines: xReLU
 using RestrictedBoltzmannMachines: nsReLU
 
@@ -76,10 +80,31 @@ function RestrictedBoltzmannMachines.save_rbm(path::AbstractString, rbm::Standar
     return path
 end
 
+function RestrictedBoltzmannMachines.save_rbm(path::AbstractString, rbm::CenteredRBM; overwrite::Bool=false)
+    if !overwrite && isfile(path)
+        error("File already exists: $path")
+    end
+    h5open(path, "w") do file
+        write(file, FILE_FORMAT_HEADER, string(FILE_FORMAT_VERSION))
+        write(file, "rbm_type", "CenteredRBM")
+        write(file, "weights", rbm.w)
+        write(file, "visible_par", rbm.visible.par)
+        write(file, "hidden_par", rbm.hidden.par)
+        write(file, "visible_type", layer_type(rbm.visible))
+        write(file, "hidden_type", layer_type(rbm.hidden))
+        write(file, "offset_v", rbm.offset_v)
+        write(file, "offset_h", rbm.offset_h)
+    end
+    return path
+end
+
 layer_type(::Binary) = "Binary"
 layer_type(::Spin) = "Spin"
 layer_type(::Potts) = "Potts"
 layer_type(::Gaussian) = "Gaussian"
+layer_type(::ReLU) = "ReLU"
+layer_type(::dReLU) = "dReLU"
+layer_type(::pReLU) = "pReLU"
 layer_type(::xReLU) = "xReLU"
 layer_type(::nsReLU) = "nsReLU"
 layer_type(::PottsGumbel) = "PottsGumbel"
@@ -90,6 +115,9 @@ construct_layer(::Val{:Binary}, par::AbstractArray) = Binary(par)
 construct_layer(::Val{:Spin}, par::AbstractArray) = Spin(par)
 construct_layer(::Val{:Potts}, par::AbstractArray) = Potts(par)
 construct_layer(::Val{:Gaussian}, par::AbstractArray) = Gaussian(par)
+construct_layer(::Val{:ReLU}, par::AbstractArray) = ReLU(par)
+construct_layer(::Val{:dReLU}, par::AbstractArray) = dReLU(par)
+construct_layer(::Val{:pReLU}, par::AbstractArray) = pReLU(par)
 construct_layer(::Val{:xReLU}, par::AbstractArray) = xReLU(par)
 construct_layer(::Val{:nsReLU}, par::AbstractArray) = nsReLU(par)
 construct_layer(::Val{:PottsGumbel}, par::AbstractArray) = PottsGumbel(par)
@@ -110,6 +138,15 @@ function _load_rbm(file::HDF5.File, ::Val{:StandardizedRBM})
     visible = construct_layer(read(file, "visible_type"), read(file, "visible_par"))
     hidden = construct_layer(read(file, "hidden_type"), read(file, "hidden_par"))
     return StandardizedRBM(visible, hidden, w, offset_v, offset_h, scale_v, scale_h)
+end
+
+function _load_rbm(file::HDF5.File, ::Val{:CenteredRBM})
+    offset_v = read(file, "offset_v")
+    offset_h = read(file, "offset_h")
+    w = read(file, "weights")
+    visible = construct_layer(read(file, "visible_type"), read(file, "visible_par"))
+    hidden = construct_layer(read(file, "hidden_type"), read(file, "hidden_par"))
+    return CenteredRBM(visible, hidden, w, offset_v, offset_h)
 end
 
 end

--- a/test/hdf5.jl
+++ b/test/hdf5.jl
@@ -1,14 +1,18 @@
 import HDF5
 using RestrictedBoltzmannMachines: Binary
+using RestrictedBoltzmannMachines: CenteredRBM
 using RestrictedBoltzmannMachines: Gaussian
 using RestrictedBoltzmannMachines: load_rbm
 using RestrictedBoltzmannMachines: Potts
 using RestrictedBoltzmannMachines: PottsGumbel
 using RestrictedBoltzmannMachines: RBM
+using RestrictedBoltzmannMachines: ReLU
 using RestrictedBoltzmannMachines: save_rbm
 using RestrictedBoltzmannMachines: Spin
 using RestrictedBoltzmannMachines: standardize
 using RestrictedBoltzmannMachines: StandardizedRBM
+using RestrictedBoltzmannMachines: dReLU
+using RestrictedBoltzmannMachines: pReLU
 using RestrictedBoltzmannMachines: xReLU
 using RestrictedBoltzmannMachines: nsReLU
 using Test: @test
@@ -74,6 +78,75 @@ end
     @test loaded_rbm.w == rbm.w
     @test loaded_rbm.visible.θ == rbm.visible.θ
     @test loaded_rbm.hidden.θ == rbm.hidden.θ
+end
+
+@testset "ReLU" begin
+    rbm = RBM(Binary(; θ=randn(2,3)), ReLU(; θ=randn(4), γ=randn(4)), randn(2,3,4))
+    path = save_rbm(tempname(), rbm)
+    loaded_rbm = load_rbm(path)
+    @test loaded_rbm.visible isa Binary
+    @test loaded_rbm.hidden isa ReLU
+    @test loaded_rbm.w == rbm.w
+    @test loaded_rbm.visible.θ == rbm.visible.θ
+    @test loaded_rbm.hidden.θ == rbm.hidden.θ
+    @test loaded_rbm.hidden.γ == rbm.hidden.γ
+end
+
+@testset "dReLU" begin
+    rbm = RBM(
+        Binary(; θ=randn(2,3)),
+        dReLU(; θp=randn(4), θn=randn(4), γp=randn(4), γn=randn(4)),
+        randn(2,3,4),
+    )
+    path = save_rbm(tempname(), rbm)
+    loaded_rbm = load_rbm(path)
+    @test loaded_rbm.visible isa Binary
+    @test loaded_rbm.hidden isa dReLU
+    @test loaded_rbm.w == rbm.w
+    @test loaded_rbm.visible.θ == rbm.visible.θ
+    @test loaded_rbm.hidden.θp == rbm.hidden.θp
+    @test loaded_rbm.hidden.θn == rbm.hidden.θn
+    @test loaded_rbm.hidden.γp == rbm.hidden.γp
+    @test loaded_rbm.hidden.γn == rbm.hidden.γn
+end
+
+@testset "pReLU" begin
+    rbm = RBM(
+        Binary(; θ=randn(2,3)),
+        pReLU(; θ=randn(4), γ=randn(4), Δ=randn(4), η=randn(4)),
+        randn(2,3,4),
+    )
+    path = save_rbm(tempname(), rbm)
+    loaded_rbm = load_rbm(path)
+    @test loaded_rbm.visible isa Binary
+    @test loaded_rbm.hidden isa pReLU
+    @test loaded_rbm.w == rbm.w
+    @test loaded_rbm.visible.θ == rbm.visible.θ
+    @test loaded_rbm.hidden.θ == rbm.hidden.θ
+    @test loaded_rbm.hidden.γ == rbm.hidden.γ
+    @test loaded_rbm.hidden.Δ == rbm.hidden.Δ
+    @test loaded_rbm.hidden.η == rbm.hidden.η
+end
+
+@testset "centered" begin
+    rbm = CenteredRBM(
+        Binary(; θ=randn(2,3)),
+        ReLU(; θ=randn(4), γ=randn(4)),
+        randn(2,3,4),
+        randn(2,3),
+        randn(4),
+    )
+    path = save_rbm(tempname(), rbm)
+    loaded_rbm = load_rbm(path)
+
+    @test loaded_rbm.visible isa Binary
+    @test loaded_rbm.hidden isa ReLU
+    @test loaded_rbm.w == rbm.w
+    @test loaded_rbm.visible.θ == rbm.visible.θ
+    @test loaded_rbm.hidden.θ == rbm.hidden.θ
+    @test loaded_rbm.hidden.γ == rbm.hidden.γ
+    @test loaded_rbm.offset_v == rbm.offset_v
+    @test loaded_rbm.offset_h == rbm.offset_h
 end
 
 @testset "std" begin


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the HDF5 extension with serialization support for the remaining layer types and `CenteredRBM`.

### Layer types added
- `ReLU`
- `dReLU`
- `pReLU`

### Model type added
- `CenteredRBM` (`save_rbm` / `load_rbm` with `offset_v` and `offset_h`)

The file format version remains `1.0.0`; new layer and model tags are backward compatible with existing files.

## Changes

- `ext/HDF5Ext.jl`: register new `layer_type` / `construct_layer` entries and add `CenteredRBM` save/load methods mirroring the existing `StandardizedRBM` pattern.
- `test/hdf5.jl`: round-trip tests for `ReLU`, `dReLU`, `pReLU`, and `CenteredRBM`.

## Testing

```bash
julia --project=test test/hdf5.jl
```

All 10 test sets pass (88 assertions total).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8b4537-c3fd-42a8-987f-6aa633ece2ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8b4537-c3fd-42a8-987f-6aa633ece2ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

