### PR TITLE
Add developer docs section; note why Potts samples stay BitArrays

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -59,6 +59,11 @@ Documenter.makedocs(
             "AIS" => "literate/ais.md",
             "Metropolis" => "literate/metropolis.md",
         ],
+        "Developer notes" => [
+            "Architecture" => "developer/architecture.md",
+            "Design & performance notes" => "developer/design_notes.md",
+            "Testing & releasing" => "developer/testing.md",
+        ],
         "Reference" => "reference.md"
     ]
 )

--- a/docs/src/developer/architecture.md
+++ b/docs/src/developer/architecture.md
@@ -1,0 +1,60 @@
+# Architecture
+
+This page documents internal conventions of the package. It is aimed at
+contributors; nothing here is needed to *use* the package.
+
+## Array dimension convention
+
+Data arrays have layer dimensions first and the batch dimension last. For a
+layer of size `(N,)`, a single sample is a vector of length `N` and a batch is
+a matrix of size `(N, B)`. For Potts layers of size `(Q, N)`, a batch has size
+`(Q, N, B)`.
+
+The weight array `w` has size `(size(visible)..., size(hidden)...)`. Functions
+like `energy`, `free_energy` and `sample_from_inputs` follow this convention
+and broadcast over trailing batch dimensions.
+
+Internally, matrix products flatten the layer dimensions: `flat_w(rbm)`
+reshapes `w` to `(length(visible), length(hidden))`, and `inputs_h_from_v`
+computes `wflat' * vflat` with a single dense matrix multiplication (BLAS on
+CPU, CUBLAS on GPU).
+
+## Layer types and parameter storage
+
+`AbstractLayer{N}` (where `N = ndims` of the layer) is the base type for all
+unit types. Each layer implements: `energy`, `cgfs`, `sample_from_inputs`,
+`mean_from_inputs`, `var_from_inputs`, `mode_from_inputs`.
+
+All layers store their parameters in a single `.par` array. Its first
+dimension indexes the parameters of the layer type (1 for `Binary` / `Spin` /
+`Potts`, which only have `θ`; 2 for `Gaussian`, which has `θ` and `γ`; 4 for
+`dReLU`). The remaining dimensions are the layer's spatial dimensions, so
+`ndims(par) == N + 1`. Named parameter accessors such as `layer.θ` and
+`layer.γ` are views into `.par`. Storing everything in one array makes
+optimizer updates and GPU transfers simple (one array per layer).
+
+`Potts` is special: it is an `AbstractLayer{2}` whose first dimension is the
+one-hot (categorical) dimension with `Q` classes and whose second dimension is
+the number of sites. So `size(potts_layer) == (Q, N)` and `par` has size
+`(1, Q, N)`.
+
+`RBM{V,H,W}` holds the `visible` layer, `hidden` layer and weights `w`. It is
+extended by `CenteredRBM` (offsets) and `StandardizedRBM` (offsets and
+scales).
+
+## Module organization
+
+- `src/layers/` — layer type definitions. `abstractlayer.jl` defines the
+  interface; each file implements one layer type; `common.jl` has shared
+  utilities.
+- `src/rbms/` — convenience constructors (`BinaryRBM`, `HopfieldRBM`, ...).
+- `src/train/` — training: `pcd.jl` (persistent contrastive divergence),
+  `initialization.jl` (data-driven init), `gradient.jl`.
+- `src/gauge/` — gauge transformations: `zerosum.jl`, `rescale_hidden.jl`,
+  `shift_fields.jl`.
+- `src/util/` — linear algebra helpers, one-hot encoding, truncated normal
+  sampling.
+- `ext/` — package extensions for CUDA (GPU support) and HDF5 (save / load).
+
+The repository uses Julia workspaces (`[workspace]` in `Project.toml`) with
+sub-projects: `test`, `docs`, `notebooks`, `repl`.

--- a/docs/src/developer/design_notes.md
+++ b/docs/src/developer/design_notes.md
@@ -1,0 +1,69 @@
+# Design and performance notes
+
+Records of design decisions that were benchmarked, so they are not revisited
+without rechecking the numbers. Benchmarks below were run in July 2026 on an
+NVIDIA RTX PRO 6000 (GPU) and a multithreaded CPU with OpenBLAS, with
+`Float32` weights and typical protein-model sizes (`Q ≈ 5–21`,
+visible `≈ 2_000–10_000`, hidden `≈ 100–1_000`, batch `≈ 256–4_000`).
+
+## Why Potts samples are onehot `BitArray`s, not floats
+
+`sample_from_inputs` for `Potts` and `PottsGumbel` returns a onehot
+`BitArray`. The float conversion happens later, inside `inputs_h_from_v` /
+`inputs_v_from_h`, where `with_eltype_of` converts the sample to the weight
+eltype right before the matrix multiplication.
+
+Returning floats from the sampler (to skip that conversion) is not worth it:
+
+- **GPU:** the conversion is within noise next to the `w'v` matmul
+  (measured speedups of 0.84–1.17× across sizes, i.e. none), while float
+  onehots occupy 32× the memory of a `BitArray`. Persistent chains in PCD
+  would pay that memory cost permanently, for no speed gain.
+- **CPU:** the `BitArray → Float32` unpack is 27–57% of the input projection,
+  so dropping it looks like a 1.9–2.9× win on that step in isolation. But
+  part of that cost would simply move into the sampler, which would then
+  write a 32× larger float array instead of a compact `BitArray`.
+
+## Why onehot × weights is a dense matmul, not indexing / gather
+
+Multiplying a onehot array by the weight matrix is mathematically a row
+selection, and libraries with huge vocabularies implement it that way:
+Flux.jl's `OneHotArray` overloads `*` as indexing (`NNlib.gather`), and
+PyTorch's `nn.Embedding` is an `index_select`. That pays off when the
+category dimension is large (vocabulary sizes of ``10^4``–``10^5``): the
+dense product would waste time multiplying by zeros.
+
+Here `Q` is small (2–21), so the "wasted" factor is small and the dense
+product runs at gemm speed. Benchmarks: CUBLAS beats an `NNlib.gather`-based
+path by 4–8× on GPU; on CPU, gather only wins (~1.5×) for very large models.
+A gather path also needs a custom kernel to avoid materializing a
+`hidden × N × batch` intermediate when summing over sites. Not worth the
+complexity at these sizes.
+
+## Categorical sampling: inverse-CDF vs the Gumbel trick
+
+`Potts` samples with `categorical_sample_from_logits`, an inverse-CDF scalar
+loop (softmax, one uniform per site, linear scan). This is the fastest option
+on CPU (~2.5–3× faster than Gumbel-argmax) but cannot run on GPU (scalar
+indexing).
+
+`PottsGumbel` samples with the Gumbel-argmax trick
+(`argmax(logits .+ gumbel_noise)`), which is GPU-friendly but draws `Q`
+random numbers per site instead of one.
+
+For reference, PyTorch's `Categorical.sample()` on GPU does *not* use Gumbel:
+`torch.multinomial` with one sample uses a fused inverse-CDF kernel
+(`sampleMultinomialOnce`: per-distribution prefix sum + one uniform + bucket
+search). PyTorch reserves Gumbel for the differentiable relaxation
+(`gumbel_softmax`) and for without-replacement sampling — neither of which
+Gibbs sampling needs.
+
+A fused inverse-CDF CUDA kernel (one thread per site: max, exp-sum, one
+uniform, linear scan over `Q`) measured **4.6–16× faster** than
+Gumbel-argmax on GPU, because it draws `Q`× fewer random numbers and
+materializes no `Q × N × B` temporaries. Note the fusion is essential: a
+*vectorized* inverse-CDF built from library ops (`softmax → cumsum → count`)
+is **slower** than Gumbel (0.4–0.77×) because of the intermediates. If GPU
+Potts sampling ever becomes a bottleneck, the right move is such a kernel in
+the CUDA extension — it is exact (no relaxation) and would make `PottsGumbel`
+unnecessary for speed.

--- a/docs/src/developer/testing.md
+++ b/docs/src/developer/testing.md
@@ -1,0 +1,42 @@
+# Testing and releasing
+
+## Running tests
+
+```bash
+# Run all tests
+julia --project=. -e 'using Pkg; Pkg.test()'
+
+# Run a single test file (uses the test/ project for test-only deps like Zygote, QuadGK)
+julia --project=test test/pcd.jl
+```
+
+Tests in `test/runtests.jl` are organized as independent modules (each file is
+wrapped in its own `module`), so each test file can also be run standalone.
+Tests use property-based checks across dimensions, and gradient checking with
+Zygote and FiniteDifferences.
+
+## GPU testing without a GPU
+
+GitHub CI has no GPU. GPU compatibility is tested in `test/jlarrays.jl` using
+[JLArrays](https://github.com/JuliaGPU/GPUArrays.jl) with
+`allowscalar(false)`, which catches scalar-indexing code paths that would fail
+on a real GPU. Do not commit tests that require physical GPU hardware; run
+those locally only.
+
+## Releasing a new version
+
+During development the version in `Project.toml` carries a `-DEV` suffix
+(e.g. `5.4.0-DEV`), and changes accumulate under an `## Unreleased` section in
+`CHANGELOG.md`. To release:
+
+1. On `master`, make a single commit titled `vX.Y.Z` that drops the `-DEV`
+   suffix from `version` in `Project.toml` and renames the `## Unreleased`
+   CHANGELOG section to `## X.Y.Z`. Push it.
+2. Comment `@JuliaRegistrator register` on that commit on GitHub, including
+   release notes (markdown, typically the CHANGELOG entries for this version)
+   in the same comment. The notes are added to the registry PR and to the
+   GitHub release that TagBot creates. Registrator opens a PR in the General
+   registry; once it merges, TagBot creates the `vX.Y.Z` tag and GitHub
+   release automatically.
+3. When starting work on the next version, bump `Project.toml` to the next
+   `-DEV` version and add a fresh `## Unreleased` section to `CHANGELOG.md`.

--- a/src/layers/potts.jl
+++ b/src/layers/potts.jl
@@ -51,11 +51,8 @@ end
 
 # Samples are onehot BitArrays, not floats (also for PottsGumbel, which shares this
 # encoding). Returning floats here, to avoid the BitArray -> float conversion later in
-# inputs_h_from_v / inputs_v_from_h, is not worth it: on GPU that conversion is
-# negligible next to the w'v matmul (within noise), while float onehots take 32x the
-# memory; on CPU the conversion is ~30-60% of the input projection, but part of that
-# cost would just move here as writes of the 32x larger float sample.
-# (Benchmarked July 2026 on an RTX PRO 6000.)
+# inputs_h_from_v / inputs_v_from_h, is not worth it; see the benchmarks in the
+# "Design and performance notes" page of the developer docs.
 function sample_from_inputs(layer::Potts, inputs = 0)
     c = categorical_sample_from_logits(layer.θ .+ inputs)
     return onehot_encode(c, 1:size(layer, 1))

--- a/src/layers/potts.jl
+++ b/src/layers/potts.jl
@@ -49,6 +49,13 @@ function meanvar_from_inputs(layer::Potts, inputs = 0)
     return μ, ν
 end
 
+# Samples are onehot BitArrays, not floats (also for PottsGumbel, which shares this
+# encoding). Returning floats here, to avoid the BitArray -> float conversion later in
+# inputs_h_from_v / inputs_v_from_h, is not worth it: on GPU that conversion is
+# negligible next to the w'v matmul (within noise), while float onehots take 32x the
+# memory; on CPU the conversion is ~30-60% of the input projection, but part of that
+# cost would just move here as writes of the 32x larger float sample.
+# (Benchmarked July 2026 on an RTX PRO 6000.)
 function sample_from_inputs(layer::Potts, inputs = 0)
     c = categorical_sample_from_logits(layer.θ .+ inputs)
     return onehot_encode(c, 1:size(layer, 1))


### PR DESCRIPTION
Two related changes:

1. **Developer notes section in the docs** (new sidebar group between Examples and Reference):
   - *Architecture* — array dimension convention, `.par` parameter storage, layer interface, module layout.
   - *Design & performance notes* — benchmarked decisions, recorded so they aren't revisited without rechecking: why Potts/PottsGumbel samples are onehot `BitArray`s rather than floats; why onehot × weights is a dense gemm rather than gather/indexing (contrast with Flux `OneHotArray` / PyTorch `nn.Embedding`, which target huge vocabularies); inverse-CDF vs Gumbel categorical sampling, including the finding that a fused inverse-CDF CUDA kernel is 4.6–16× faster than Gumbel-argmax on GPU.
   - *Testing & releasing* — running tests, JLArrays-based GPU testing on CI, release procedure.
2. **Code comment** at `sample_from_inputs(::Potts)` pointing to the design-notes page.

Benchmark summary behind the BitArray decision (real `inputs_h_from_v` path: `BitArray → Float32` conversion followed by `wflat' * vflat`, RTX PRO 6000, July 2026):

- **GPU:** dropping the conversion gives 0.84–1.17× — within noise; the gemm dominates. Float onehots would cost 32× the memory for no speedup.
- **CPU:** the conversion is 27–57% of the input projection (1.85–2.9× if dropped in isolation), but part of that cost would just move into writing the 32× larger float sample at sampling time.

Docs-and-comments only; no behavior affected. Docs CI builds the new pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1MpRKxoeowhTF56eMcBPN