### PR TITLE
Fix zerosum! for StandardizedRBM and CenteredRBM with nontrivial offsets/scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fixed `zerosum!` for `StandardizedRBM` and `CenteredRBM` with nontrivial offsets/scales. Previously it applied the plain-`RBM` zerosum to the standardized (centered) parameters directly, which changed the modeled distribution (not a gauge transformation) — corrupting `pcd!` training of such models with Potts layers. The zerosum gauge is now imposed on the equivalent unstandardized (uncentered) model, preserving free energies up to an additive constant. Also added out-of-place `zerosum(::StandardizedRBM)` and `zerosum(::CenteredRBM)`.
+
 ## 5.4.0
 
 - Added `ucd!` trainer (Unbiased Contrastive Divergence) and `unbiased_sample` sampler.

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -301,11 +301,23 @@ end
 In-place version of `zerosum(rbm)`. Offsets are not modified.
 """
 function zerosum!(rbm::CenteredRBM)
-    if has_potts_layers(rbm)
-        gauged = zerosum(rbm)
-        rbm.visible.par .= gauged.visible.par
-        rbm.hidden.par .= gauged.hidden.par
-        rbm.w .= gauged.w
+    if rbm.visible isa Union{Potts, PottsGumbel}
+        ωv = mean(rbm.w; dims = 1)
+        rbm.w .-= ωv
+        zerosum!(rbm.visible.θ; dims = 1)
+        # Compensate hidden fields. Unlike a plain RBM, the interaction involves
+        # v - offset_v, so the color-sum of the visible offsets enters the shift.
+        vdims = ntuple(identity, ndims(rbm.visible))
+        Ov = sum(rbm.offset_v; dims = 1)
+        shift_fields!(rbm.hidden, reshape(sum(ωv .* (1 .- Ov); dims = vdims), size(rbm.hidden)))
+    end
+    if rbm.hidden isa Union{Potts, PottsGumbel}
+        ωh = mean(rbm.w; dims = ndims(rbm.visible) + 1)
+        rbm.w .-= ωh
+        zerosum!(rbm.hidden.θ; dims = 1)
+        hdims = ntuple(d -> d + ndims(rbm.visible), ndims(rbm.hidden))
+        Oh = reshape(sum(rbm.offset_h; dims = 1), map(one, size(rbm.visible))..., 1, size(rbm.hidden)[2:end]...)
+        shift_fields!(rbm.visible, reshape(sum(ωh .* (1 .- Oh); dims = hdims), size(rbm.visible)))
     end
     return rbm
 end

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -278,8 +278,35 @@ function center_from_data!(rbm::CenteredRBM, data::AbstractArray; wts=nothing)
     return rbm
 end
 
+"""
+    zerosum(rbm::CenteredRBM)
+
+Returns an equivalent `CenteredRBM`, with the same offsets, whose equivalent uncentered
+`RBM` (see [`uncenter`](@ref)) is in the zerosum gauge. Only affects Potts layers.
+If the `rbm` doesn't have `Potts` layers, does nothing.
+
+Note that the gauge condition applies to the uncentered parameters: since the interaction
+energy involves the centered `v - offset_v`, sums over Potts colors of the centered
+weights are compensated differently than in a plain `RBM`.
+"""
+function zerosum(rbm::CenteredRBM)
+    has_potts_layers(rbm) || return rbm
+    plain = zerosum(uncenter(rbm))
+    return center(plain, rbm.offset_v, rbm.offset_h)
+end
+
+"""
+    zerosum!(rbm::CenteredRBM)
+
+In-place version of `zerosum(rbm)`. Offsets are not modified.
+"""
 function zerosum!(rbm::CenteredRBM)
-    zerosum!(RBM(rbm))
+    if has_potts_layers(rbm)
+        gauged = zerosum(rbm)
+        rbm.visible.par .= gauged.visible.par
+        rbm.hidden.par .= gauged.hidden.par
+        rbm.w .= gauged.w
+    end
     return rbm
 end
 

--- a/src/gauge/zerosum.jl
+++ b/src/gauge/zerosum.jl
@@ -1,6 +1,10 @@
 zerosum(A::AbstractArray; dims = 1) = A .- mean(A; dims)
 zerosum!(A::AbstractArray; dims = 1) = A .= zerosum(A; dims)
 
+# zerosum only affects Potts layers
+has_potts_layers(rbm) =
+    rbm.visible isa Union{Potts,PottsGumbel} || rbm.hidden isa Union{Potts,PottsGumbel}
+
 """
     zerosum(rbm)
 

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -192,8 +192,36 @@ function rescale_hidden_activations!(rbm::StandardizedRBM)
     return false
 end
 
+"""
+    zerosum(rbm::StandardizedRBM)
+
+Returns an equivalent `StandardizedRBM`, with the same offsets and scales, whose
+equivalent unstandardized `RBM` (see [`unstandardize`](@ref)) is in the zerosum gauge.
+Only affects Potts layers. If the `rbm` doesn't have `Potts` layers, does nothing.
+
+Note that the gauge condition applies to the unstandardized parameters: the standardized
+weights and fields need not sum to zero over Potts colors, because the interaction energy
+involves the standardized `(v - offset_v) / scale_v`, for which sums over colors are not
+constant when the offsets and scales vary across colors.
+"""
+function zerosum(rbm::StandardizedRBM)
+    has_potts_layers(rbm) || return rbm
+    plain = zerosum(unstandardize(rbm))
+    return standardize(plain, rbm.offset_v, rbm.offset_h, rbm.scale_v, rbm.scale_h)
+end
+
+"""
+    zerosum!(rbm::StandardizedRBM)
+
+In-place version of `zerosum(rbm)`. Offsets and scales are not modified.
+"""
 function zerosum!(rbm::StandardizedRBM)
-    zerosum!(RBM(rbm))
+    if has_potts_layers(rbm)
+        gauged = zerosum(rbm)
+        rbm.visible.par .= gauged.visible.par
+        rbm.hidden.par .= gauged.hidden.par
+        rbm.w .= gauged.w
+    end
     return rbm
 end
 

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -216,11 +216,28 @@ end
 In-place version of `zerosum(rbm)`. Offsets and scales are not modified.
 """
 function zerosum!(rbm::StandardizedRBM)
-    if has_potts_layers(rbm)
-        gauged = zerosum(rbm)
-        rbm.visible.par .= gauged.visible.par
-        rbm.hidden.par .= gauged.hidden.par
-        rbm.w .= gauged.w
+    if rbm.visible isa Union{Potts, PottsGumbel}
+        # Gauge move on the unstandardized weights w̃ = w / (scale_v ⊗ scale_h):
+        # subtract their mean over visible colors (scale_h cancels out of the w update).
+        ξ = mean(rbm.w ./ rbm.scale_v; dims = 1)
+        rbm.w .-= ξ .* rbm.scale_v
+        zerosum!(rbm.visible.θ; dims = 1)
+        # Compensate hidden fields. Unlike a plain RBM, the interaction involves
+        # v - offset_v, so the color-sum of the visible offsets enters the shift.
+        vdims = ntuple(identity, ndims(rbm.visible))
+        Ov = sum(rbm.offset_v; dims = 1)
+        Δθh = reshape(sum(ξ .* (1 .- Ov); dims = vdims), size(rbm.hidden)) ./ rbm.scale_h
+        shift_fields!(rbm.hidden, Δθh)
+    end
+    if rbm.hidden isa Union{Potts, PottsGumbel}
+        scale_h = reshape(rbm.scale_h, map(one, size(rbm.visible))..., size(rbm.hidden)...)
+        ζ = mean(rbm.w ./ scale_h; dims = ndims(rbm.visible) + 1)
+        rbm.w .-= ζ .* scale_h
+        zerosum!(rbm.hidden.θ; dims = 1)
+        hdims = ntuple(d -> d + ndims(rbm.visible), ndims(rbm.hidden))
+        Oh = reshape(sum(rbm.offset_h; dims = 1), map(one, size(rbm.visible))..., 1, size(rbm.hidden)[2:end]...)
+        Δθv = reshape(sum(ζ .* (1 .- Oh); dims = hdims), size(rbm.visible)) ./ rbm.scale_v
+        shift_fields!(rbm.visible, Δθv)
     end
     return rbm
 end

--- a/test/gauge/zerosum.jl
+++ b/test/gauge/zerosum.jl
@@ -3,7 +3,8 @@ using LinearAlgebra: norm
 using Statistics: mean
 using RestrictedBoltzmannMachines: zerosum, zerosum!, zerosum_weights, free_energy,
     RBM, Potts, Binary, Spin, Gaussian, ReLU, dReLU, pReLU, xReLU, sample_from_inputs,
-    PottsGumbel, potts_to_gumbel, gumbel_to_potts, ∂RBM, ∂free_energy
+    PottsGumbel, potts_to_gumbel, gumbel_to_potts, ∂RBM, ∂free_energy,
+    standardize, unstandardize, CenteredRBM, center, uncenter
 
 @testset "zerosum (visible Potts)" begin
     N = (3, 2, 3)
@@ -263,4 +264,114 @@ end
     result3 = zerosum_weights(w3, rbm_g3)
     result3_p = zerosum_weights(w3, gumbel_to_potts(rbm_g3))
     @test result3 ≈ result3_p
+end
+
+@testset "zerosum StandardizedRBM with nontrivial offsets/scales (visible Potts)" begin
+    N = (3, 2)
+    M = (2,)
+    rbm = RBM(Potts(; θ = randn(N...)), Binary(; θ = randn(M...)), randn(N..., M...))
+    srbm = standardize(rbm)
+    srbm.offset_v .= randn(N...) / 3
+    srbm.scale_v .= 1 .+ rand(N...)
+    srbm.offset_h .= randn(M...) / 3
+    srbm.scale_h .= 1 .+ rand(M...)
+
+    v = sample_from_inputs(srbm.visible, zeros(N..., 1000))
+    F0 = free_energy(srbm, v)
+
+    srbm1 = zerosum(srbm)
+    # gauge transformation: free energies shift by an additive constant only
+    F1 = free_energy(srbm1, v)
+    @test all(F0 - F1 .≈ mean(F0 - F1))
+    # offsets and scales are preserved
+    @test srbm1.offset_v == srbm.offset_v
+    @test srbm1.offset_h == srbm.offset_h
+    @test srbm1.scale_v == srbm.scale_v
+    @test srbm1.scale_h == srbm.scale_h
+    # the equivalent unstandardized RBM is in zerosum gauge
+    urbm = unstandardize(srbm1)
+    @test norm(mean(urbm.w; dims=1)) < 1e-10
+    @test norm(mean(urbm.visible.θ; dims=1)) < 1e-10
+    # idempotent
+    srbm2 = zerosum(srbm1)
+    @test srbm2.w ≈ srbm1.w
+    @test srbm2.visible.par ≈ srbm1.visible.par
+    @test srbm2.hidden.par ≈ srbm1.hidden.par
+
+    # in-place version agrees with out-of-place version
+    srbm! = deepcopy(srbm)
+    zerosum!(srbm!)
+    @test srbm!.w ≈ srbm1.w
+    @test srbm!.visible.par ≈ srbm1.visible.par
+    @test srbm!.hidden.par ≈ srbm1.hidden.par
+    @test srbm!.offset_v == srbm.offset_v
+    @test srbm!.scale_v == srbm.scale_v
+end
+
+@testset "zerosum StandardizedRBM with nontrivial offsets/scales (hidden Potts)" begin
+    N = (2,)
+    M = (3, 2)
+    rbm = RBM(Binary(; θ = randn(N...)), Potts(; θ = randn(M...)), randn(N..., M...))
+    srbm = standardize(rbm)
+    srbm.offset_v .= randn(N...) / 3
+    srbm.scale_v .= 1 .+ rand(N...)
+    srbm.offset_h .= randn(M...) / 3
+    srbm.scale_h .= 1 .+ rand(M...)
+
+    v = sample_from_inputs(srbm.visible, zeros(N..., 1000))
+    F0 = free_energy(srbm, v)
+    srbm1 = zerosum(srbm)
+    F1 = free_energy(srbm1, v)
+    @test all(F0 - F1 .≈ mean(F0 - F1))
+    urbm = unstandardize(srbm1)
+    @test norm(mean(urbm.w; dims=ndims(srbm.visible) + 1)) < 1e-10
+    @test norm(mean(urbm.hidden.θ; dims=1)) < 1e-10
+
+    srbm! = deepcopy(srbm)
+    zerosum!(srbm!)
+    @test free_energy(srbm!, v) ≈ F1
+end
+
+@testset "zerosum StandardizedRBM no-op for non-Potts" begin
+    srbm = standardize(RBM(Binary(; θ = randn(2)), Binary(; θ = randn(3)), randn(2, 3)))
+    srbm.offset_v .= randn(2) / 3
+    @test zerosum(srbm) === srbm
+    w = copy(srbm.w)
+    zerosum!(srbm)
+    @test srbm.w == w
+end
+
+@testset "zerosum CenteredRBM with nontrivial offsets" begin
+    N = (3, 2)
+    M = (2,)
+    rbm = RBM(Potts(; θ = randn(N...)), Binary(; θ = randn(M...)), randn(N..., M...))
+    crbm = CenteredRBM(deepcopy(rbm))
+    crbm.offset_v .= randn(N...) / 3
+    crbm.offset_h .= randn(M...) / 3
+
+    v = sample_from_inputs(crbm.visible, zeros(N..., 1000))
+    F0 = free_energy(crbm, v)
+
+    crbm1 = zerosum(crbm)
+    F1 = free_energy(crbm1, v)
+    @test all(F0 - F1 .≈ mean(F0 - F1))
+    @test crbm1.offset_v == crbm.offset_v
+    @test crbm1.offset_h == crbm.offset_h
+    # the equivalent uncentered RBM is in zerosum gauge
+    urbm = uncenter(crbm1)
+    @test norm(mean(urbm.w; dims=1)) < 1e-10
+    @test norm(mean(urbm.visible.θ; dims=1)) < 1e-10
+
+    crbm! = deepcopy(crbm)
+    zerosum!(crbm!)
+    @test crbm!.w ≈ crbm1.w
+    @test crbm!.visible.par ≈ crbm1.visible.par
+    @test crbm!.hidden.par ≈ crbm1.hidden.par
+    @test free_energy(crbm!, v) ≈ F1
+end
+
+@testset "zerosum CenteredRBM no-op for non-Potts" begin
+    crbm = CenteredRBM(RBM(Binary(; θ = randn(2)), Binary(; θ = randn(3)), randn(2, 3)))
+    crbm.offset_v .= randn(2) / 3
+    @test zerosum(crbm) === crbm
 end

--- a/test/gauge/zerosum.jl
+++ b/test/gauge/zerosum.jl
@@ -375,3 +375,56 @@ end
     crbm.offset_v .= randn(2) / 3
     @test zerosum(crbm) === crbm
 end
+
+@testset "zerosum StandardizedRBM with nontrivial offsets/scales (both Potts)" begin
+    N = (3, 2)
+    M = (3, 2)
+    rbm = RBM(Potts(; θ = randn(N...)), Potts(; θ = randn(M...)), randn(N..., M...))
+    srbm = standardize(rbm)
+    srbm.offset_v .= randn(N...) / 3
+    srbm.scale_v .= 1 .+ rand(N...)
+    srbm.offset_h .= randn(M...) / 3
+    srbm.scale_h .= 1 .+ rand(M...)
+
+    v = sample_from_inputs(srbm.visible, zeros(N..., 1000))
+    F0 = free_energy(srbm, v)
+    srbm1 = zerosum(srbm)
+    F1 = free_energy(srbm1, v)
+    @test all(F0 - F1 .≈ mean(F0 - F1))
+    urbm = unstandardize(srbm1)
+    @test norm(mean(urbm.w; dims=1)) < 1e-10
+    @test norm(mean(urbm.w; dims=ndims(srbm.visible) + 1)) < 1e-10
+    @test norm(mean(urbm.visible.θ; dims=1)) < 1e-10
+    @test norm(mean(urbm.hidden.θ; dims=1)) < 1e-10
+
+    # in-place (sequential passes) agrees with out-of-place (joint round trip)
+    srbm! = deepcopy(srbm)
+    zerosum!(srbm!)
+    @test srbm!.w ≈ srbm1.w
+    @test srbm!.visible.par ≈ srbm1.visible.par
+    @test srbm!.hidden.par ≈ srbm1.hidden.par
+end
+
+@testset "zerosum! StandardizedRBM with PottsGumbel visible" begin
+    N = (3, 2)
+    M = (2,)
+    rbm_g = RBM(PottsGumbel(; θ = randn(N...)), Binary(; θ = randn(M...)), randn(N..., M...))
+    srbm_g = standardize(rbm_g)
+    srbm_g.offset_v .= randn(N...) / 3
+    srbm_g.scale_v .= 1 .+ rand(N...)
+    srbm_g.offset_h .= randn(M...) / 3
+    srbm_g.scale_h .= 1 .+ rand(M...)
+
+    v = sample_from_inputs(srbm_g.visible, zeros(N..., 1000))
+    F0 = free_energy(srbm_g, v)
+    srbm_g! = deepcopy(srbm_g)
+    zerosum!(srbm_g!)
+    @test srbm_g!.visible isa PottsGumbel
+    F1 = free_energy(srbm_g!, v)
+    @test all(F0 - F1 .≈ mean(F0 - F1))
+    # agrees with out-of-place
+    srbm_g1 = zerosum(srbm_g)
+    @test srbm_g!.w ≈ srbm_g1.w
+    @test srbm_g!.visible.par ≈ srbm_g1.visible.par
+    @test srbm_g!.hidden.par ≈ srbm_g1.hidden.par
+end

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -178,6 +178,21 @@ end
     rescale_weights!(rbm)
     @test adapt(Array, jl_rbm.w) ≈ rbm.w
     @test adapt(Array, jl_rbm.hidden.par) ≈ rbm.hidden.par
+
+    # zerosum! on StandardizedRBM with nontrivial offsets/scales
+    std_rbm = StandardizedRBM(
+        Potts(; θ = randn(Q, N...)),
+        ReLU(; θ = randn(3), γ = 1 .+ rand(3)),
+        randn(Q, N..., 3) / √(Q * prod(N)),
+        randn(Q, N...) / 3, randn(3) / 3,
+        1 .+ rand(Q, N...), 1 .+ rand(3),
+    )
+    jl_std_rbm = adapt(JLArray, std_rbm)
+    zerosum!(jl_std_rbm)
+    zerosum!(std_rbm)
+    @test adapt(Array, jl_std_rbm.w) ≈ std_rbm.w
+    @test adapt(Array, jl_std_rbm.visible.par) ≈ std_rbm.visible.par
+    @test adapt(Array, jl_std_rbm.hidden.par) ≈ std_rbm.hidden.par
 end
 
 @testset "initialize! and pcd!" begin

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -193,6 +193,22 @@ end
     @test adapt(Array, jl_std_rbm.w) ≈ std_rbm.w
     @test adapt(Array, jl_std_rbm.visible.par) ≈ std_rbm.visible.par
     @test adapt(Array, jl_std_rbm.hidden.par) ≈ std_rbm.hidden.par
+
+    # both-Potts StandardizedRBM: exercises the hidden-Potts in-place branch (with its
+    # scale_h / offset_h color-sum reshapes) under allowscalar(false).
+    std_rbm2 = StandardizedRBM(
+        Potts(; θ = randn(Q, N...)),
+        Potts(; θ = randn(Q, 3)),
+        randn(Q, N..., Q, 3) / √(Q * prod(N)),
+        randn(Q, N...) / 3, randn(Q, 3) / 3,
+        1 .+ rand(Q, N...), 1 .+ rand(Q, 3),
+    )
+    jl_std_rbm2 = adapt(JLArray, std_rbm2)
+    zerosum!(jl_std_rbm2)
+    zerosum!(std_rbm2)
+    @test adapt(Array, jl_std_rbm2.w) ≈ std_rbm2.w
+    @test adapt(Array, jl_std_rbm2.visible.par) ≈ std_rbm2.visible.par
+    @test adapt(Array, jl_std_rbm2.hidden.par) ≈ std_rbm2.hidden.par
 end
 
 @testset "initialize! and pcd!" begin


### PR DESCRIPTION
## Summary

Fixed a critical bug in `zerosum!` for `StandardizedRBM` and `CenteredRBM` that was corrupting the modeled distribution when these models had nontrivial offsets and/or scales. Previously, the zerosum gauge transformation was applied directly to the standardized (centered) parameters, which is not a gauge transformation and changed the model's distribution. This broke `pcd!` training of such models with Potts layers.

## Key Changes

- **`src/standardized.jl`**: Rewrote `zerosum!` to apply the gauge transformation to the equivalent unstandardized RBM, then preserve the offsets and scales. The implementation accounts for how the interaction energy involves `(v - offset_v) / scale_v`, so the compensation of hidden fields must include the color-sum of visible offsets.

- **`src/centered.jl`**: Rewrote `zerosum!` similarly to apply the gauge transformation to the equivalent uncentered RBM while preserving offsets. The compensation logic accounts for the centered interaction `v - offset_v`.

- **`src/gauge/zerosum.jl`**: Added helper function `has_potts_layers(rbm)` to check if an RBM has Potts layers (only these are affected by zerosum).

- **`src/standardized.jl` and `src/centered.jl`**: Added `zerosum(rbm)` out-of-place versions that return an equivalent model with the same offsets/scales but whose unstandardized (uncentered) equivalent is in zerosum gauge.

- **Test coverage**: Added comprehensive test suites covering:
  - StandardizedRBM with nontrivial offsets/scales (visible Potts, hidden Potts, both Potts)
  - CenteredRBM with nontrivial offsets
  - No-op behavior for non-Potts layers
  - PottsGumbel visible layers
  - Verification that free energies shift by constant only (gauge transformation property)
  - In-place and out-of-place versions agree
  - GPU compatibility via JLArrays

## Implementation Details

The key insight is that for a StandardizedRBM, the interaction energy is `w · (v - offset_v) / scale_v · h / scale_h`, not `w · v · h`. When applying zerosum to the unstandardized weights `w̃ = w / (scale_v ⊗ scale_h)`, the color-sum of visible offsets enters the hidden field compensation because `∑_v (v - offset_v) = ∑_v v - Q·offset_v` (where Q is the number of colors). Similarly for hidden Potts layers.

The out-of-place versions (`zerosum(rbm)`) work by unstandardizing, applying the plain zerosum, then re-standardizing with the original offsets and scales preserved.

https://claude.ai/code/session_01PzQjJbqMbhCzPXsqT2P7NG