### PR TITLE
v5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 5.5.0
 
+- Added HDF5 support for the ReLU-family layers (`ReLU`, `dReLU`, `pReLU`) and for `CenteredRBM` serialization [#103](https://github.com/cossio/RestrictedBoltzmannMachines.jl/pull/103).
 - Fixed `zerosum!` for `StandardizedRBM` and `CenteredRBM` with nontrivial offsets/scales. Previously it applied the plain-`RBM` zerosum to the standardized (centered) parameters directly, which changed the modeled distribution (not a gauge transformation) — corrupting `pcd!` training of such models with Potts layers. The zerosum gauge is now imposed on the equivalent unstandardized (uncentered) model, preserving free energies up to an additive constant. Also added out-of-place `zerosum(::StandardizedRBM)` and `zerosum(::CenteredRBM)`.
 
 ## 5.4.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "5.4.1-DEV"
+version = "5.5.0"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Release version 5.5.0 with HDF5 support for ReLU-family layers and improved zerosum gauge handling.

## Summary

This release adds HDF5 serialization support for ReLU-family layers (`ReLU`, `dReLU`, `pReLU`) and `CenteredRBM`, and fixes a critical bug in the zerosum gauge transformation for `StandardizedRBM` and `CenteredRBM` models.

## Key Changes

- **HDF5 Support**: Added serialization support for ReLU-family layers and `CenteredRBM` (see #103)
- **Zerosum Gauge Fix**: Fixed `zerosum!` for `StandardizedRBM` and `CenteredRBM` to correctly preserve the modeled distribution. Previously, the zerosum gauge was applied directly to standardized/centered parameters, which changed the distribution rather than performing a gauge transformation. This corrupted PCD training of such models with Potts layers. The fix applies the zerosum gauge to the equivalent unstandardized/uncentered model, preserving free energies up to an additive constant.
- **New API**: Added out-of-place `zerosum(::StandardizedRBM)` and `zerosum(::CenteredRBM)` functions

## Version Bump

- Updated `Project.toml` version from `5.4.1-DEV` to `5.5.0`
- Updated `CHANGELOG.md` to document the release

https://claude.ai/code/session_014GZaa8jhY2Bp91d8Bbkeb4