### PR TITLE
Add gradient projection for zerosum gauge in StandardizedRBM and CenteredRBM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 
 - Added gradient projections `zerosum!(∂, ::StandardizedRBM)` and `zerosum!(∂, ::CenteredRBM)`, which project the gradient so that a gradient step doesn't modify the zerosum gauge of the equivalent unstandardized (uncentered) model, consistent with the gauge introduced in [#108](https://github.com/cossio/RestrictedBoltzmannMachines.jl/pull/108). `∂regularize!` for these models gains the same `zerosum` keyword as the plain-`RBM` method, and their `pcd!` trainers now pass `zerosum` through to it, projecting the gradient every iteration like the plain path does ([#110](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/110)).
-- Fixed `zerosum!(∂, ::RBM)`, which was discarding the Potts field gradients entirely instead of projecting them: it applied the zerosum over dim 1 of the `par`-shaped gradient arrays `(1, Q, ...)`, which is the singleton parameter-type dimension rather than the color dimension, zeroing `∂.visible`/`∂.hidden`. This silently froze Potts fields during `pcd!`/`ucd!` training whenever `zerosum=true` (the default). The projection now acts on the color dimension.
+- Fixed `zerosum!(∂, ::RBM)`, which was discarding the Potts field gradients entirely instead of projecting them: it applied the zerosum over dim 1 of the `par`-shaped gradient arrays `(1, Q, ...)`, which is the singleton parameter-type dimension rather than the color dimension, zeroing `∂.visible`/`∂.hidden`. This silently froze Potts fields during `pcd!` training whenever `zerosum=true` (the default). The projection now acts on the color dimension.
 
 ## 5.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Added gradient projections `zerosum!(∂, ::StandardizedRBM)` and `zerosum!(∂, ::CenteredRBM)`, which project the gradient so that a gradient step doesn't modify the zerosum gauge of the equivalent unstandardized (uncentered) model, consistent with the gauge introduced in [#108](https://github.com/cossio/RestrictedBoltzmannMachines.jl/pull/108). `∂regularize!` for these models gains the same `zerosum` keyword as the plain-`RBM` method, and their `pcd!` trainers now pass `zerosum` through to it, projecting the gradient every iteration like the plain path does ([#110](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/110)).
+- Fixed `zerosum!(∂, ::RBM)`, which was discarding the Potts field gradients entirely instead of projecting them: it applied the zerosum over dim 1 of the `par`-shaped gradient arrays `(1, Q, ...)`, which is the singleton parameter-type dimension rather than the color dimension, zeroing `∂.visible`/`∂.hidden`. This silently froze Potts fields during `pcd!`/`ucd!` training whenever `zerosum=true` (the default). The projection now acts on the color dimension.
+
 ## 5.5.0
 
 - Added HDF5 support for the ReLU-family layers (`ReLU`, `dReLU`, `pReLU`) and for `CenteredRBM` serialization [#103](https://github.com/cossio/RestrictedBoltzmannMachines.jl/pull/103).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "5.5.0"
+version = "5.6.0-DEV"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -322,6 +322,16 @@ function zerosum!(rbm::CenteredRBM)
     return rbm
 end
 
+"""
+    zerosum!(∂, rbm::CenteredRBM)
+
+Projects the gradient so that it doesn't modify the zerosum gauge of the equivalent
+uncentered `RBM` (see [`uncenter`](@ref)), with offsets held fixed. Since uncentering
+leaves the weights unchanged, the gauge conditions on the centered parameters coincide
+with the plain `RBM` ones.
+"""
+zerosum!(∂::∂RBM, rbm::CenteredRBM) = zerosum!(∂, RBM(rbm))
+
 function rescale_weights!(rbm::CenteredRBM)
     rescale_weights!(RBM(rbm))
     return rbm
@@ -339,6 +349,7 @@ function ∂regularize!(
     l1_weights::Real = 0,
     l2_weights::Real = 0,
     l2l1_weights::Real = 0,
+    zerosum::Bool = false # whether to zerosum gradients
 )
     urbm = uncenter(rbm)
     offset_h = reshape(rbm.offset_h, map(one, size(rbm.offset_v))..., size(rbm.offset_h)...)
@@ -358,6 +369,8 @@ function ∂regularize!(
         dims = ntuple(identity, ndims(rbm.visible))
         ∂.w .+= l2l1_weights * sign.(urbm.w) .* mean(abs, urbm.w; dims)
     end
+    zerosum && zerosum!(∂, rbm)
+    return ∂
 end
 
 function ∂regularize_add_visible_offset!(∂::∂RBM, visible_regularization::AbstractArray, offset_h::AbstractArray, ::dReLU)
@@ -466,7 +479,7 @@ function pcd!(
         ∂ *= batch_weight
 
         # weight decay
-        ∂regularize!(∂, rbm; l2_fields, l1_weights, l2_weights, l2l1_weights)
+        ∂regularize!(∂, rbm; l2_fields, l1_weights, l2_weights, l2l1_weights, zerosum)
 
         # feed gradient to Optimiser rule
         gs = (; visible = ∂.visible, hidden = ∂.hidden, w = ∂.w)

--- a/src/gauge/zerosum.jl
+++ b/src/gauge/zerosum.jl
@@ -68,11 +68,11 @@ Projects the gradient so that it doesn't modify the zerosum gauge.
 function zerosum!(∂::∂RBM, rbm::RBM)
     # ∂.visible and ∂.hidden have the layer `par` layout, where dim 1 indexes the
     # parameter type (θ, singleton for Potts) and dim 2 the Potts colors.
-    if rbm.visible isa Potts
+    if rbm.visible isa Union{Potts, PottsGumbel}
         zerosum!(∂.visible; dims = 2)
         zerosum!(∂.w; dims = 1)
     end
-    if rbm.hidden isa Potts
+    if rbm.hidden isa Union{Potts, PottsGumbel}
         zerosum!(∂.hidden; dims = 2)
         zerosum!(∂.w; dims = ndims(rbm.visible) + 1)
     end
@@ -125,10 +125,6 @@ function zerosum!(rbm::RBM{<:AbstractLayer, <:PottsGumbel})
     _rbm = zerosum!(gumbel_to_potts(rbm))
     return RBM(_rbm.visible, PottsGumbel(_rbm.hidden), _rbm.w)
 end
-
-zerosum!(∂::∂RBM, rbm::RBM{<:PottsGumbel, <:PottsGumbel}) = zerosum!(∂, gumbel_to_potts(rbm))
-zerosum!(∂::∂RBM, rbm::RBM{<:AbstractLayer, <:PottsGumbel}) = zerosum!(∂, gumbel_to_potts(rbm))
-zerosum!(∂::∂RBM, rbm::RBM{<:PottsGumbel, <:AbstractLayer}) = zerosum!(∂, gumbel_to_potts(rbm))
 
 zerosum_weights(weights::AbstractArray, rbm::RBM{<:PottsGumbel, <:PottsGumbel}) = zerosum_weights(weights, gumbel_to_potts(rbm))
 zerosum_weights(weights::AbstractArray, rbm::RBM{<:AbstractLayer, <:PottsGumbel}) = zerosum_weights(weights, gumbel_to_potts(rbm))

--- a/src/gauge/zerosum.jl
+++ b/src/gauge/zerosum.jl
@@ -66,12 +66,14 @@ end
 Projects the gradient so that it doesn't modify the zerosum gauge.
 """
 function zerosum!(∂::∂RBM, rbm::RBM)
+    # ∂.visible and ∂.hidden have the layer `par` layout, where dim 1 indexes the
+    # parameter type (θ, singleton for Potts) and dim 2 the Potts colors.
     if rbm.visible isa Potts
-        zerosum!(∂.visible; dims = 1)
+        zerosum!(∂.visible; dims = 2)
         zerosum!(∂.w; dims = 1)
     end
     if rbm.hidden isa Potts
-        zerosum!(∂.hidden; dims = 1)
+        zerosum!(∂.hidden; dims = 2)
         zerosum!(∂.w; dims = ndims(rbm.visible) + 1)
     end
     return ∂

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -131,7 +131,8 @@ function ∂regularize!(
     l1_weights::Real = 0,
     l2_weights::Real = 0,
     l2l1_weights::Real = 0,
-    regularize_unstandardized::Bool = true
+    regularize_unstandardized::Bool = true,
+    zerosum::Bool = false # whether to zerosum gradients
 )
     if regularize_unstandardized
         # regularization applies the unstandardized parameters
@@ -161,6 +162,8 @@ function ∂regularize!(
         # regularization applies directly to standardized parameters
         ∂regularize!(∂, RBM(std_rbm); l2_fields, l1_weights, l2_weights, l2l1_weights)
     end
+    zerosum && zerosum!(∂, std_rbm)
+    return ∂
 end
 
 function ∂regularize_add_visible_offset!(∂::∂RBM, visible_regularization::AbstractArray, offset_h::AbstractArray, scale_w::AbstractArray, ::dReLU)
@@ -240,6 +243,32 @@ function zerosum!(rbm::StandardizedRBM)
         shift_fields!(rbm.visible, Δθv)
     end
     return rbm
+end
+
+"""
+    zerosum!(∂, rbm::StandardizedRBM)
+
+Projects the gradient so that it doesn't modify the zerosum gauge of the equivalent
+unstandardized `RBM` (see [`unstandardize`](@ref)), with offsets and scales held fixed.
+
+As in `zerosum!(rbm::StandardizedRBM)`, the gauge condition applies to the
+unstandardized parameters: for the weights it reads `sum(w ./ scale_v; dims = 1) == 0`
+over Potts colors (and similarly for hidden Potts with `scale_h`), so the gradient
+component removed here is the corresponding gauge direction `ξ .* scale_v`.
+"""
+function zerosum!(∂::∂RBM, rbm::StandardizedRBM)
+    if rbm.visible isa Union{Potts, PottsGumbel}
+        zerosum!(∂.visible; dims = 2) # dim 1 of `par` is the (singleton) parameter type
+        ξ = mean(∂.w ./ rbm.scale_v; dims = 1)
+        ∂.w .-= ξ .* rbm.scale_v
+    end
+    if rbm.hidden isa Union{Potts, PottsGumbel}
+        zerosum!(∂.hidden; dims = 2)
+        scale_h = reshape(rbm.scale_h, map(one, size(rbm.visible))..., size(rbm.hidden)...)
+        ζ = mean(∂.w ./ scale_h; dims = ndims(rbm.visible) + 1)
+        ∂.w .-= ζ .* scale_h
+    end
+    return ∂
 end
 
 """
@@ -456,7 +485,7 @@ function pcd!(
         ∂ = ∂d - ∂m
 
         # weight decay
-        ∂regularize!(∂, rbm; l2_fields, l1_weights, l2_weights, l2l1_weights, regularize_unstandardized)
+        ∂regularize!(∂, rbm; l2_fields, l1_weights, l2_weights, l2l1_weights, regularize_unstandardized, zerosum)
 
         # feed gradient to Optimiser rule
         gs = (; visible = ∂.visible, hidden = ∂.hidden, w = ∂.w)

--- a/test/gauge/zerosum.jl
+++ b/test/gauge/zerosum.jl
@@ -3,7 +3,7 @@ using LinearAlgebra: norm
 using Statistics: mean
 using RestrictedBoltzmannMachines: zerosum, zerosum!, zerosum_weights, free_energy,
     RBM, Potts, Binary, Spin, Gaussian, ReLU, dReLU, pReLU, xReLU, sample_from_inputs,
-    PottsGumbel, potts_to_gumbel, gumbel_to_potts, ∂RBM, ∂free_energy,
+    PottsGumbel, potts_to_gumbel, gumbel_to_potts, ∂RBM, ∂free_energy, ∂regularize!,
     standardize, unstandardize, CenteredRBM, center, uncenter
 
 @testset "zerosum (visible Potts)" begin
@@ -114,10 +114,19 @@ end
     v = sample_from_inputs(rbm.visible, zeros(N..., 100))
     ∂ = ∂free_energy(rbm, v)
     zerosum!(∂, rbm)
-    # gradient on hidden should be zero-sum in dim 1
-    @test norm(mean(∂.hidden; dims=1)) < 1e-13
+    # ∂.hidden has the `par` layout (1, Q, M...); colors are dim 2
+    @test norm(mean(∂.hidden; dims=2)) < 1e-13
+    # the projection must not discard the field gradient wholesale
+    @test norm(∂.hidden) > 1e-3
     # gradient on w should be zero-sum in the hidden Potts dim (dim 3 = ndims(visible)+1)
     @test norm(mean(∂.w; dims=ndims(rbm.visible) + 1)) < 1e-13
+
+    # a gradient descent step with the projected gradient preserves the gauge
+    rbm.visible.par .-= 0.1 * ∂.visible
+    rbm.hidden.par .-= 0.1 * ∂.hidden
+    rbm.w .-= 0.1 * ∂.w
+    @test norm(mean(rbm.hidden.θ; dims=1)) < 1e-13
+    @test norm(mean(rbm.w; dims=ndims(rbm.visible) + 1)) < 1e-13
 end
 
 @testset "zerosum PottsGumbel (visible PottsGumbel, hidden Binary)" begin
@@ -209,7 +218,8 @@ end
     v = sample_from_inputs(rbm_g.visible, zeros(N..., 50))
     ∂ = ∂free_energy(rbm_g, v)
     zerosum!(∂, rbm_g)
-    @test norm(mean(∂.visible; dims=1)) < 1e-13
+    @test norm(mean(∂.visible; dims=2)) < 1e-13
+    @test norm(∂.visible) > 1e-3
     @test norm(mean(∂.w; dims=1)) < 1e-13
 
     # hidden PottsGumbel, visible Binary
@@ -220,7 +230,8 @@ end
     v2 = sample_from_inputs(rbm_g2.visible, zeros(N2..., 50))
     ∂2 = ∂free_energy(rbm_g2, v2)
     zerosum!(∂2, rbm_g2)
-    @test norm(mean(∂2.hidden; dims=1)) < 1e-13
+    @test norm(mean(∂2.hidden; dims=2)) < 1e-13
+    @test norm(∂2.hidden) > 1e-3
     @test norm(mean(∂2.w; dims=ndims(rbm_g2.visible) + 1)) < 1e-13
 
     # both PottsGumbel
@@ -231,8 +242,8 @@ end
     v3 = sample_from_inputs(rbm_g3.visible, zeros(N3..., 50))
     ∂3 = ∂free_energy(rbm_g3, v3)
     zerosum!(∂3, rbm_g3)
-    @test norm(mean(∂3.visible; dims=1)) < 1e-13
-    @test norm(mean(∂3.hidden; dims=1)) < 1e-13
+    @test norm(mean(∂3.visible; dims=2)) < 1e-13
+    @test norm(mean(∂3.hidden; dims=2)) < 1e-13
     @test norm(mean(∂3.w; dims=1)) < 1e-13
     @test norm(mean(∂3.w; dims=ndims(rbm_g3.visible) + 1)) < 1e-13
 end
@@ -427,4 +438,211 @@ end
     @test srbm_g!.w ≈ srbm_g1.w
     @test srbm_g!.visible.par ≈ srbm_g1.visible.par
     @test srbm_g!.hidden.par ≈ srbm_g1.hidden.par
+end
+
+@testset "zerosum! ∂RBM StandardizedRBM (visible Potts)" begin
+    N = (3, 2)
+    M = (2,)
+    rbm = RBM(Potts(; θ = randn(N...)), Binary(; θ = randn(M...)), randn(N..., M...))
+    srbm = standardize(rbm)
+    srbm.offset_v .= randn(N...) / 3
+    srbm.scale_v .= 1 .+ rand(N...)
+    srbm.offset_h .= randn(M...) / 3
+    srbm.scale_h .= 1 .+ rand(M...)
+    zerosum!(srbm)
+
+    v = sample_from_inputs(srbm.visible, zeros(N..., 100))
+    ∂ = ∂free_energy(srbm, v)
+    zerosum!(∂, srbm)
+    # fields gradient is zero-sum over colors (dim 2 of the `par` layout), but not discarded
+    @test norm(mean(∂.visible; dims=2)) < 1e-13
+    @test norm(∂.visible) > 1e-3
+    # weights gradient satisfies the unstandardized gauge condition
+    @test norm(mean(∂.w ./ srbm.scale_v; dims=1)) < 1e-13
+    # idempotent
+    ∂2 = deepcopy(∂)
+    zerosum!(∂2, srbm)
+    @test ∂2.visible ≈ ∂.visible
+    @test ∂2.hidden ≈ ∂.hidden
+    @test ∂2.w ≈ ∂.w
+
+    # a gradient descent step with the projected gradient preserves the gauge
+    # of the equivalent unstandardized RBM
+    srbm.visible.par .-= 0.1 * ∂.visible
+    srbm.hidden.par .-= 0.1 * ∂.hidden
+    srbm.w .-= 0.1 * ∂.w
+    urbm = unstandardize(srbm)
+    @test norm(mean(urbm.w; dims=1)) < 1e-10
+    @test norm(mean(urbm.visible.θ; dims=1)) < 1e-10
+end
+
+@testset "zerosum! ∂RBM StandardizedRBM (hidden Potts)" begin
+    N = (2,)
+    M = (3, 2)
+    rbm = RBM(Binary(; θ = randn(N...)), Potts(; θ = randn(M...)), randn(N..., M...))
+    srbm = standardize(rbm)
+    srbm.offset_v .= randn(N...) / 3
+    srbm.scale_v .= 1 .+ rand(N...)
+    srbm.offset_h .= randn(M...) / 3
+    srbm.scale_h .= 1 .+ rand(M...)
+    zerosum!(srbm)
+
+    v = sample_from_inputs(srbm.visible, zeros(N..., 100))
+    ∂ = ∂free_energy(srbm, v)
+    zerosum!(∂, srbm)
+    @test norm(mean(∂.hidden; dims=2)) < 1e-13
+    scale_h = reshape(srbm.scale_h, map(one, N)..., M...)
+    @test norm(mean(∂.w ./ scale_h; dims=ndims(srbm.visible) + 1)) < 1e-13
+
+    srbm.visible.par .-= 0.1 * ∂.visible
+    srbm.hidden.par .-= 0.1 * ∂.hidden
+    srbm.w .-= 0.1 * ∂.w
+    urbm = unstandardize(srbm)
+    @test norm(mean(urbm.w; dims=ndims(srbm.visible) + 1)) < 1e-10
+    @test norm(mean(urbm.hidden.θ; dims=1)) < 1e-10
+end
+
+@testset "zerosum! ∂RBM StandardizedRBM (both Potts)" begin
+    N = (3, 2)
+    M = (3, 2)
+    rbm = RBM(Potts(; θ = randn(N...)), Potts(; θ = randn(M...)), randn(N..., M...))
+    srbm = standardize(rbm)
+    srbm.offset_v .= randn(N...) / 3
+    srbm.scale_v .= 1 .+ rand(N...)
+    srbm.offset_h .= randn(M...) / 3
+    srbm.scale_h .= 1 .+ rand(M...)
+    zerosum!(srbm)
+
+    v = sample_from_inputs(srbm.visible, zeros(N..., 100))
+    ∂ = ∂free_energy(srbm, v)
+    zerosum!(∂, srbm)
+    @test norm(mean(∂.visible; dims=2)) < 1e-13
+    @test norm(mean(∂.hidden; dims=2)) < 1e-13
+    # both weight gauge conditions hold after the sequential projection
+    scale_h = reshape(srbm.scale_h, map(one, N)..., M...)
+    @test norm(mean(∂.w ./ srbm.scale_v; dims=1)) < 1e-13
+    @test norm(mean(∂.w ./ scale_h; dims=ndims(srbm.visible) + 1)) < 1e-13
+
+    srbm.visible.par .-= 0.1 * ∂.visible
+    srbm.hidden.par .-= 0.1 * ∂.hidden
+    srbm.w .-= 0.1 * ∂.w
+    urbm = unstandardize(srbm)
+    @test norm(mean(urbm.w; dims=1)) < 1e-10
+    @test norm(mean(urbm.w; dims=ndims(srbm.visible) + 1)) < 1e-10
+    @test norm(mean(urbm.visible.θ; dims=1)) < 1e-10
+    @test norm(mean(urbm.hidden.θ; dims=1)) < 1e-10
+end
+
+@testset "zerosum! ∂RBM StandardizedRBM reduces to plain RBM for trivial offsets/scales" begin
+    N = (3, 2)
+    M = (2,)
+    rbm = RBM(Potts(; θ = randn(N...)), Binary(; θ = randn(M...)), randn(N..., M...))
+    zerosum!(rbm)
+    srbm = standardize(deepcopy(rbm)) # zero offsets, unit scales
+    v = sample_from_inputs(rbm.visible, zeros(N..., 100))
+    ∂p = ∂free_energy(rbm, v)
+    ∂s = deepcopy(∂p)
+    zerosum!(∂p, rbm)
+    zerosum!(∂s, srbm)
+    @test ∂s.visible ≈ ∂p.visible
+    @test ∂s.hidden ≈ ∂p.hidden
+    @test ∂s.w ≈ ∂p.w
+end
+
+@testset "zerosum! ∂RBM StandardizedRBM no-op for non-Potts" begin
+    srbm = standardize(RBM(Binary(; θ = randn(2)), Binary(; θ = randn(3)), randn(2, 3)))
+    srbm.offset_v .= randn(2) / 3
+    srbm.scale_v .= 1 .+ rand(2)
+    v = sample_from_inputs(srbm.visible, zeros(2, 10))
+    ∂ = ∂free_energy(srbm, v)
+    ∂0 = deepcopy(∂)
+    zerosum!(∂, srbm)
+    @test ∂.visible == ∂0.visible
+    @test ∂.hidden == ∂0.hidden
+    @test ∂.w == ∂0.w
+end
+
+@testset "zerosum! ∂RBM StandardizedRBM with PottsGumbel visible" begin
+    N = (3, 2)
+    M = (2,)
+    rbm_g = RBM(PottsGumbel(; θ = randn(N...)), Binary(; θ = randn(M...)), randn(N..., M...))
+    srbm_g = standardize(rbm_g)
+    srbm_g.offset_v .= randn(N...) / 3
+    srbm_g.scale_v .= 1 .+ rand(N...)
+    zerosum!(srbm_g)
+    v = sample_from_inputs(srbm_g.visible, zeros(N..., 50))
+    ∂ = ∂free_energy(srbm_g, v)
+    zerosum!(∂, srbm_g)
+    @test norm(mean(∂.visible; dims=2)) < 1e-13
+    @test norm(mean(∂.w ./ srbm_g.scale_v; dims=1)) < 1e-13
+end
+
+@testset "∂regularize! zerosum pass-through (StandardizedRBM)" begin
+    # defining property from issue #110: with the projection applied to the full
+    # (free energy + regularization) gradient, a naive SGD step stays in gauge
+    # without needing the zerosum!(rbm) reset
+    N = (3, 2)
+    M = (2,)
+    rbm = RBM(Potts(; θ = randn(N...)), Binary(; θ = randn(M...)), randn(N..., M...))
+    srbm = standardize(rbm)
+    srbm.offset_v .= randn(N...) / 3
+    srbm.scale_v .= 1 .+ rand(N...)
+    srbm.offset_h .= randn(M...) / 3
+    srbm.scale_h .= 1 .+ rand(M...)
+    zerosum!(srbm)
+
+    v = sample_from_inputs(srbm.visible, zeros(N..., 100))
+    ∂ = ∂free_energy(srbm, v)
+    ∂regularize!(∂, srbm; l2_fields = 0.1, l1_weights = 0.1, l2_weights = 0.1, zerosum = true)
+    srbm.visible.par .-= 0.1 * ∂.visible
+    srbm.hidden.par .-= 0.1 * ∂.hidden
+    srbm.w .-= 0.1 * ∂.w
+    urbm = unstandardize(srbm)
+    @test norm(mean(urbm.w; dims=1)) < 1e-10
+    @test norm(mean(urbm.visible.θ; dims=1)) < 1e-10
+end
+
+@testset "∂regularize! zerosum pass-through (CenteredRBM)" begin
+    N = (3, 2)
+    M = (2,)
+    rbm = RBM(Potts(; θ = randn(N...)), Binary(; θ = randn(M...)), randn(N..., M...))
+    crbm = CenteredRBM(rbm)
+    crbm.offset_v .= randn(N...) / 3
+    crbm.offset_h .= randn(M...) / 3
+    zerosum!(crbm)
+
+    v = sample_from_inputs(crbm.visible, zeros(N..., 100))
+    ∂ = ∂free_energy(crbm, v)
+    ∂regularize!(∂, crbm; l2_fields = 0.1, l1_weights = 0.1, l2_weights = 0.1, zerosum = true)
+    crbm.visible.par .-= 0.1 * ∂.visible
+    crbm.hidden.par .-= 0.1 * ∂.hidden
+    crbm.w .-= 0.1 * ∂.w
+    urbm = uncenter(crbm)
+    @test norm(mean(urbm.w; dims=1)) < 1e-10
+    @test norm(mean(urbm.visible.θ; dims=1)) < 1e-10
+end
+
+@testset "zerosum! ∂RBM CenteredRBM" begin
+    N = (3, 2)
+    M = (2,)
+    rbm = RBM(Potts(; θ = randn(N...)), Binary(; θ = randn(M...)), randn(N..., M...))
+    crbm = CenteredRBM(rbm)
+    crbm.offset_v .= randn(N...) / 3
+    crbm.offset_h .= randn(M...) / 3
+    zerosum!(crbm)
+
+    v = sample_from_inputs(crbm.visible, zeros(N..., 100))
+    ∂ = ∂free_energy(crbm, v)
+    zerosum!(∂, crbm)
+    @test norm(mean(∂.visible; dims=2)) < 1e-13
+    @test norm(mean(∂.w; dims=1)) < 1e-13
+
+    # a gradient descent step with the projected gradient preserves the gauge
+    # of the equivalent uncentered RBM
+    crbm.visible.par .-= 0.1 * ∂.visible
+    crbm.hidden.par .-= 0.1 * ∂.hidden
+    crbm.w .-= 0.1 * ∂.w
+    urbm = uncenter(crbm)
+    @test norm(mean(urbm.w; dims=1)) < 1e-10
+    @test norm(mean(urbm.visible.θ; dims=1)) < 1e-10
 end

--- a/test/gauge/zerosum.jl
+++ b/test/gauge/zerosum.jl
@@ -129,6 +129,29 @@ end
     @test norm(mean(rbm.w; dims=ndims(rbm.visible) + 1)) < 1e-13
 end
 
+@testset "zerosum! ∂RBM leaves gauge-compatible field gradients unchanged" begin
+    #= Regression test: zerosum!(∂, rbm) used to zerosum the par-shaped field
+    gradients (1, Q, ...) over dim 1 — the singleton parameter-type dimension
+    instead of the color dimension — which zeroed them entirely.
+    For Potts layers the PCD field gradient ∂d - ∂m is automatically zero-sum
+    over colors (one-hot units sum to 1 in both the data and model phases), so
+    the projection must act as the identity on it. =#
+    N = (3, 2)
+    M = (3, 2)
+    rbm = RBM(Potts(; θ = randn(N...)), Potts(; θ = randn(M...)), randn(N..., M...))
+    zerosum!(rbm)
+    vd = sample_from_inputs(rbm.visible, zeros(N..., 50))
+    vm = sample_from_inputs(rbm.visible, zeros(N..., 50))
+    ∂ = ∂free_energy(rbm, vd) - ∂free_energy(rbm, vm)
+    ∂0 = deepcopy(∂)
+    zerosum!(∂, rbm)
+    @test ∂.visible ≈ ∂0.visible
+    @test ∂.hidden ≈ ∂0.hidden
+    # ... and the identity is meaningful only because the gradients are nonzero
+    @test norm(∂0.visible) > 1e-3
+    @test norm(∂0.hidden) > 1e-3
+end
+
 @testset "zerosum PottsGumbel (visible PottsGumbel, hidden Binary)" begin
     N = (3, 2, 3)
     M = (2, 3)

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -209,6 +209,16 @@ end
     @test adapt(Array, jl_std_rbm2.w) ≈ std_rbm2.w
     @test adapt(Array, jl_std_rbm2.visible.par) ≈ std_rbm2.visible.par
     @test adapt(Array, jl_std_rbm2.hidden.par) ≈ std_rbm2.hidden.par
+
+    # gradient projection zerosum!(∂, rbm) on both-Potts StandardizedRBM
+    v = sample_from_inputs(std_rbm2.visible, zeros(Q, N..., 16))
+    ∂ = ∂free_energy(std_rbm2, v)
+    jl_∂ = adapt(JLArray, ∂)
+    zerosum!(jl_∂, jl_std_rbm2)
+    zerosum!(∂, std_rbm2)
+    @test adapt(Array, jl_∂.visible) ≈ ∂.visible
+    @test adapt(Array, jl_∂.hidden) ≈ ∂.hidden
+    @test adapt(Array, jl_∂.w) ≈ ∂.w
 end
 
 @testset "initialize! and pcd!" begin

--- a/test/train.jl
+++ b/test/train.jl
@@ -168,6 +168,23 @@ end
     @test norm(mean(rbm.w; dims = 1)) < 1e-10
 end
 
+@testset "pcd potts learns visible fields" begin
+    #= Regression test: zerosum!(∂, rbm) used to discard Potts field gradients
+    entirely (it zerosummed the par-shaped gradient over the singleton
+    parameter-type dim instead of the color dim), so pcd! with zerosum=true
+    (the default) silently froze the visible fields at their initial values.
+    The moment-matching tests above miss this because initialize! already sets
+    the fields near their maximum-likelihood values. Starting from zero fields
+    on data with non-uniform color frequencies, training must move the fields. =#
+    seed!(69)
+    data = potts_dataset()
+    rbm = RBM(Potts((3, 2)), Binary((3,)), zeros(3, 2, 3))
+    pcd!(rbm, data; batchsize = 32, iters = 100, steps = 5, optim = Descent(1e-2))
+    @test norm(rbm.visible.θ) > 1e-3
+    # while staying in the zerosum gauge
+    @test norm(mean(rbm.visible.θ; dims = 1)) < 1e-10
+end
+
 @testset "pcd gaussian hidden moment matching" begin
     seed!(53)
     data = binary_dataset()

--- a/test/train.jl
+++ b/test/train.jl
@@ -15,7 +15,7 @@ using Optimisers: Adam, Descent
 using RestrictedBoltzmannMachines: RBM, BinaryRBM, Binary, Spin, Potts, Gaussian,
     pcd!, ucd!, initialize!, free_energy, log_likelihood, log_partition,
     collect_states, mean_h_from_v, generate_sequences, onehot_encode,
-    center, standardize, weight_norms
+    center, standardize, unstandardize, weight_norms
 
 all_visible_states(layer::Union{Binary,Spin}) = collect_states(layer)
 
@@ -203,6 +203,21 @@ end
     @test gaps.v < 0.05
     @test gaps.h < 0.05
     @test gaps.vh < 0.05
+end
+
+@testset "standardized pcd potts moment matching" begin
+    seed!(63)
+    data = potts_dataset()
+    rbm = standardize(initialize!(RBM(Potts((3, 2)), Binary((3,)), zeros(3, 2, 3)), data))
+    pcd!(rbm, data; batchsize = 32, iters = 5000, steps = 5, optim = Adam(1e-3))
+    gaps = moment_gaps(rbm, data)
+    @test gaps.v < 0.05
+    @test gaps.h < 0.05
+    @test gaps.vh < 0.05
+    # zerosum gauge of the equivalent unstandardized RBM is maintained
+    urbm = unstandardize(rbm)
+    @test norm(mean(urbm.visible.θ; dims = 1)) < 1e-10
+    @test norm(mean(urbm.w; dims = 1)) < 1e-10
 end
 
 @testset "ucd moment matching" begin


### PR DESCRIPTION
Closes #110

## Summary

Adds gradient projection methods `zerosum!(∂, ::StandardizedRBM)` and `zerosum!(∂, ::CenteredRBM)` that ensure gradient steps preserve the zerosum gauge of the equivalent unstandardized/uncentered RBM. This allows training with regularization and gauge constraints without needing periodic `zerosum!(rbm)` resets.

## Key Changes

- **`src/gauge/zerosum.jl`**: Fixed dimension indices in `zerosum!(∂, ::RBM)` — Potts color dimension is `dim=2` (not `dim=1`) in the layer `par` layout where `dim=1` indexes parameter types. The old code subtracted the mean over the singleton parameter-type dimension, which zeroed the Potts field gradients entirely, silently freezing Potts fields during `pcd!`/`ucd!` training whenever `zerosum=true` (the default).

- **`src/standardized.jl`**: 
  - Added `zerosum!(∂::∂RBM, rbm::StandardizedRBM)` that projects gradients to preserve the unstandardized gauge: removes the gauge direction `ξ .* scale_v` from weights and `ζ .* scale_h` from weights for Potts visible/hidden layers respectively.
  - Added `zerosum::Bool = false` keyword to `∂regularize!` for StandardizedRBM; when `true`, applies the gradient projection after regularization.
  - Updated `pcd!` to pass the `zerosum` flag to `∂regularize!`.

- **`src/centered.jl`**:
  - Added `zerosum!(∂::∂RBM, rbm::CenteredRBM)` that delegates to the plain RBM projection (since uncentering leaves weights unchanged).
  - Added `zerosum::Bool = false` keyword to `∂regularize!` for CenteredRBM.
  - Updated `pcd!` to pass the `zerosum` flag to `∂regularize!`.

- **`test/gauge/zerosum.jl`**: 
  - Corrected existing tests to use `dims=2` for Potts color dimension, and added assertions that the projected field gradients are not discarded wholesale.
  - Added comprehensive test suites for `zerosum!(∂, ::StandardizedRBM)` covering visible Potts, hidden Potts, both Potts, and PottsGumbel cases, including the defining property from #110: a naive SGD step with the projected gradient stays in gauge without the `zerosum!(rbm)` reset.
  - Added tests for `zerosum!(∂, ::CenteredRBM)`.
  - Added tests verifying that `∂regularize!` with `zerosum=true` maintains gauge after gradient steps.
  - Added tests confirming the projection reduces to plain RBM behavior for trivial offsets/scales and is a no-op for non-Potts layers.

- **`test/train.jl`**: Added test for standardized PCD training on Potts data, verifying that the gauge of the equivalent unstandardized RBM is maintained after training.

- **`test/jlarrays.jl`**: Added GPU compatibility test for `zerosum!(∂, ::StandardizedRBM)` on both-Potts models.

- **`CHANGELOG.md`**: Documented the new feature and the fix under `## Unreleased`.

- **`Project.toml`**: Bumped version to `5.6.0-DEV`.

## Implementation Details

The gradient projection for StandardizedRBM accounts for the relationship between standardized and unstandardized parameters. For Potts layers, the gauge condition on the unstandardized model (e.g., `sum(w ./ scale_v; dims=1) == 0`) translates to removing the component `mean(∂.w ./ scale_v; dims=1) .* scale_v` from the weight gradient. This ensures that a gradient step with the projected gradient preserves the gauge of the equivalent unstandardized RBM, even when combined with regularization.

https://claude.ai/code/session_01M7VVAqKypVR5kL2jJ6BypF