### PR TITLE
Add test coverage tracking with Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,10 @@ jobs:
       - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38
       - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1
       - uses: julia-actions/julia-runtest@6e050c8013b833b1195105ff2fce9cd802f53271
-      - uses: julia-actions/julia-processcoverage@51f6c28a089e613035452e069b8a002671dd24a5
-      - uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1
+        with:
+          coverage: true
+      - uses: julia-actions/julia-processcoverage@03114f09f119417c3242a9fb6e0b722676aedf38
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,9 @@ jobs:
       - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38
       - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1
       - uses: julia-actions/julia-runtest@6e050c8013b833b1195105ff2fce9cd802f53271
+      - uses: julia-actions/julia-processcoverage@51f6c28a089e613035452e069b8a002671dd24a5
+      - uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- CI now collects test coverage and uploads it to [Codecov](https://codecov.io/gh/cossio/RestrictedBoltzmannMachines.jl).
 - Added gradient projections `zerosum!(∂, ::StandardizedRBM)` and `zerosum!(∂, ::CenteredRBM)`, which project the gradient so that a gradient step doesn't modify the zerosum gauge of the equivalent unstandardized (uncentered) model, consistent with the gauge introduced in [#108](https://github.com/cossio/RestrictedBoltzmannMachines.jl/pull/108). `∂regularize!` for these models gains the same `zerosum` keyword as the plain-`RBM` method, and their `pcd!` trainers now pass `zerosum` through to it, projecting the gradient every iteration like the plain path does ([#110](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/110)).
 - Fixed `zerosum!(∂, ::RBM)`, which was discarding the Potts field gradients entirely instead of projecting them: it applied the zerosum over dim 1 of the `par`-shaped gradient arrays `(1, Q, ...)`, which is the singleton parameter-type dimension rather than the color dimension, zeroing `∂.visible`/`∂.hidden`. This silently froze Potts fields during `pcd!` training whenever `zerosum=true` (the default). The projection now acts on the color dimension.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Docs (stable)](https://img.shields.io/badge/docs-stable-blue.svg)](https://cossio.github.io/RestrictedBoltzmannMachines.jl/stable)
 [![Docs (dev)](https://img.shields.io/badge/docs-dev-blue.svg)](https://cossio.github.io/RestrictedBoltzmannMachines.jl/dev)
+[![Coverage](https://codecov.io/gh/cossio/RestrictedBoltzmannMachines.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/cossio/RestrictedBoltzmannMachines.jl)
 
 A Julia package for training and sampling [Restricted Boltzmann Machines](https://en.wikipedia.org/wiki/Restricted_Boltzmann_machine) (RBMs) — a class of probabilistic generative models with a bipartite structure of visible and hidden units. This package supports a wide range of unit types (binary, spin, Potts, Gaussian, ReLU variants), GPU acceleration via CUDA, and advanced techniques like centered and standardized RBMs.
 


### PR DESCRIPTION
## Summary

This PR adds automated test coverage collection and reporting to the CI pipeline, integrating with Codecov to track code coverage over time.

## Changes

- **CI workflow** (`.github/workflows/ci.yml`): Added two new steps to the test job:
  - `julia-actions/julia-processcoverage` to collect coverage data from tests
  - `codecov/codecov-action` to upload coverage reports to Codecov, with the token stored securely in `CODECOV_TOKEN` secret and error reporting disabled to prevent CI failures due to upload issues

- **Documentation** (`README.md`): Added a Codecov coverage badge linking to the project's coverage dashboard

- **Changelog** (`CHANGELOG.md`): Documented the new coverage tracking feature under the Unreleased section

## Implementation Details

The coverage upload is configured to:
- Use the standard `lcov.info` coverage file generated by Julia's coverage tools
- Fail gracefully if the upload fails (`fail_ci_if_error: false`) to avoid blocking merges due to temporary Codecov outages
- Require the `CODECOV_TOKEN` secret to be configured in the repository settings for authentication

https://claude.ai/code/session_0196ZiCNaLWyridoWAjaAyvV