### PR TITLE
v5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 5.6.0
 
 - CI now collects test coverage and uploads it to [Codecov](https://codecov.io/gh/cossio/RestrictedBoltzmannMachines.jl).
 - Codecov status checks are now blocking instead of informational: overall project coverage may not drop by more than 1% in a PR, and the lines changed by a PR must be at least 85% covered, so new code is required to come with tests. Coverage upload failures now fail CI on trusted runs (pushes and same-repo PRs; fork PRs can't access the Codecov token, so their uploads stay best-effort), and `ext/CUDAExt.jl` is excluded from coverage since it only loads with a physical GPU.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "5.6.0-DEV"
+version = "5.6.0"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Release commit for **v5.6.0**: drops the `-DEV` suffix in `Project.toml` and renames the `## Unreleased` CHANGELOG section to `## 5.6.0`.

Once merged, I'll post `@JuliaRegistrator register` (with release notes) on the resulting `master` commit to kick off registration.

## Changes in this release

- CI now collects test coverage and uploads it to [Codecov](https://codecov.io/gh/cossio/RestrictedBoltzmannMachines.jl).
- Codecov status checks are now blocking instead of informational: overall project coverage may not drop by more than 1% in a PR, and the lines changed by a PR must be at least 85% covered, so new code is required to come with tests. Coverage upload failures now fail CI on trusted runs (pushes and same-repo PRs; fork PRs can't access the Codecov token, so their uploads stay best-effort), and `ext/CUDAExt.jl` is excluded from coverage since it only loads with a physical GPU.
- Fixed the no-argument methods `standardize_visible(::StandardizedRBM)` and `standardize_hidden(::StandardizedRBM)`, which always threw a `MethodError` (they broadcast `ones` instead of `one` over the scale arrays).
- Removed `src/train/minibatches.jl` (`minibatches`, `minibatch_count`, `training_epochs`), which was dead code: it was not included in the module (superseded by `infinite_minibatches`).
- Added tests for many previously uncovered paths.
- Added gradient projections `zerosum!(∂, ::StandardizedRBM)` and `zerosum!(∂, ::CenteredRBM)` ([#110](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/110)).
- Fixed `zerosum!(∂, ::RBM)`, which was discarding the Potts field gradients entirely instead of projecting them, silently freezing Potts fields during `pcd!` training whenever `zerosum=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5bRctn8xYgv2ru7hGvpcN)_