### PR TITLE
Start v5.6.1-DEV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
 ## 5.6.0
 
 - CI now collects test coverage and uploads it to [Codecov](https://codecov.io/gh/cossio/RestrictedBoltzmannMachines.jl).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "5.6.0"
+version = "5.6.1-DEV"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Opens the next development cycle after the v5.6.0 release (registered in [JuliaRegistries/General#160823](https://github.com/JuliaRegistries/General/pull/160823)):

- Bumps `version` in `Project.toml` from `5.6.0` to `5.6.1-DEV`.
- Adds a fresh `## Unreleased` section at the top of `CHANGELOG.md` to collect changes for the next release.

This follows step 3 of the release workflow in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5bRctn8xYgv2ru7hGvpcN)_