### PR TITLE
v5.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 5.7.0
 
 - Fixed `xReLU(layer::nsReLU)`, which built the fixed `γ = 1` array with `ones(size(layer.θ))`, always returning a host `Array{Float64}`. Since this conversion backs `energies`, `cgfs`, `∂cgfs`, `sample_from_inputs` and the other moment functions of `nsReLU`, it promoted the entire hidden-layer computation to `Float64` and, on GPU, forced a host allocation plus a host→device transfer on every call. It now uses `one.(layer.θ)`, preserving both eltype and device ([#119](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/119)).
 - Fixed `rescale_weights!(::CenteredRBM)`, which changed the modeled distribution (not a gauge transformation) when the hidden units are continuous and the hidden offsets are nonzero: it delegated to the plain-`RBM` method, rescaling the hidden layer and the weights but not `offset_h`, even though the interaction involves `h - offset_h`. This corrupted `pcd!` training of centered RBMs with continuous hidden units (`rescale=true` is the default). Added `rescale_hidden!(::CenteredRBM, λ)` and `weight_norms(::CenteredRBM)`, mirroring the `StandardizedRBM` methods. `rescale_weights!(::CenteredRBM)` now returns a `Bool` (whether the rescaling was applied) instead of the RBM, consistent with the `RBM` and `StandardizedRBM` methods.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "5.6.1-DEV"
+version = "5.7.0"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Release version 5.7.0 with bug fixes for `nsReLU` and `CenteredRBM`.

## Summary

This release fixes two important bugs affecting GPU compatibility and correctness of centered RBM training:

1. **`xReLU(layer::nsReLU)` GPU/dtype preservation** — The fixed `γ = 1` array was constructed with `ones(size(layer.θ))`, which always returned a host `Array{Float64}`. This forced promotion of hidden-layer computations to `Float64` and caused unnecessary host allocations and transfers on GPU for `energies`, `cgfs`, `∂cgfs`, `sample_from_inputs`, and other moment functions. Now uses `one.(layer.θ)` to preserve both element type and device placement.

2. **`rescale_weights!(::CenteredRBM)` correctness** — The method was delegating to the plain-`RBM` implementation, which rescaled the hidden layer and weights but not `offset_h`. Since the interaction involves `h - offset_h`, this changed the modeled distribution (not a gauge transformation) and corrupted `pcd!` training of centered RBMs with continuous hidden units. Added `rescale_hidden!(::CenteredRBM, λ)` and `weight_norms(::CenteredRBM)` methods mirroring `StandardizedRBM`, and changed `rescale_weights!(::CenteredRBM)` to return a `Bool` (whether rescaling was applied) for consistency with other RBM variants.

## Changes

- Updated CHANGELOG.md: moved entries from `## Unreleased` to `## 5.7.0`
- Updated Project.toml: bumped version from `5.6.1-DEV` to `5.7.0`

https://claude.ai/code/session_01Y45mgEw1sVskqGUozXCc9V