### PR TITLE
Add CI for agent docs and Claude-powered PR review

### DIFF
--- a/.agents/skills/restricted-boltzmann-machines-jl/references/architecture.md
+++ b/.agents/skills/restricted-boltzmann-machines-jl/references/architecture.md
@@ -21,9 +21,8 @@ Read this file when you need the package map or repo-specific edit guidance.
 - `src/rbm.jl` and `src/rbms/`
   Core RBM types plus convenience constructors and variants.
 - `src/train/`
-  Initialization, PCD, gradients, and minibatch-related training helpers.
-  Note that `src/train/minibatches.jl` exists but is not currently included by
-  the root module.
+  Initialization, PCD, gradients, and minibatch iteration helpers
+  (`src/train/infinite_minibatches.jl`).
 - `src/gauge/`
   Gauge transforms such as zero-sum, hidden rescaling, and field shifting.
 - `src/pseudolikelihood.jl`, `src/partition.jl`, `src/ais.jl`,

--- a/.agents/skills/restricted-boltzmann-machines-jl/references/architecture.md
+++ b/.agents/skills/restricted-boltzmann-machines-jl/references/architecture.md
@@ -21,7 +21,7 @@ Read this file when you need the package map or repo-specific edit guidance.
 - `src/rbm.jl` and `src/rbms/`
   Core RBM types plus convenience constructors and variants.
 - `src/train/`
-  Initialization, PCD, gradients, and minibatch iteration helpers
+  Initialization, PCD, UCD, gradients, and minibatch iteration helpers
   (`src/train/infinite_minibatches.jl`).
 - `src/gauge/`
   Gauge transforms such as zero-sum, hidden rescaling, and field shifting.

--- a/.github/scripts/lint_agent_docs.py
+++ b/.github/scripts/lint_agent_docs.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Lint agent-instruction files (CLAUDE.md, AGENTS.md, agent skills).
+
+Deterministic checks that keep these files honest and slim:
+
+- size budgets, so the context these files consume stays small
+- SKILL.md frontmatter rules from the Agent Skills spec
+  (https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
+- repo paths mentioned in the docs must exist (staleness check)
+- ``--project=<dir>`` flags must point at real Julia projects
+- long lines duplicated verbatim across files are reported (redundancy signal)
+
+Semantic checks (contradictions, redundancy in meaning, guideline adherence)
+are handled by the Claude review job in .github/workflows/agent-docs.yml.
+
+Errors fail CI (exit 1); warnings are annotated but do not fail.
+Runs with the Python 3 standard library only (PyYAML is used when available).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+LIMITS = {
+    # CLAUDE.md / AGENTS.md are loaded into context on every session.
+    "memory_lines": 250,
+    "memory_bytes": 16_000,
+    # Agent Skills spec: keep SKILL.md under 500 lines, push detail to references.
+    "skill_lines": 500,
+    "skill_name_len": 64,
+    "skill_desc_len": 1024,
+    "reference_lines": 1000,
+    # Below this length a description cannot say what the skill does *and* when to use it.
+    "skill_desc_min": 40,
+    # Lines shorter than this are too generic for the duplicate check.
+    "dup_min_len": 45,
+}
+
+MEMORY_FILES = ["CLAUDE.md", "AGENTS.md", ".claude/CLAUDE.md"]
+SKILL_GLOBS = [".agents/skills/*/SKILL.md", ".claude/skills/*/SKILL.md"]
+
+# Tokens starting with these are treated as repo paths that must exist.
+DIR_PREFIXES = (
+    "src/", "test/", "docs/", "ext/", "repl/", "notebooks/", "example/",
+    "references/", "agents/", ".claude/", ".agents/", ".github/",
+)
+# Bare filenames treated as repo-root paths (committed files only —
+# Manifest.toml is intentionally absent because it is gitignored).
+TOP_LEVEL_FILES = {
+    "CLAUDE.md", "AGENTS.md", "README.md", "CHANGELOG.md", "Project.toml",
+    "LICENSE.md", "CITATION.cff", "codecov.yml", "SKILL.md",
+}
+# Tokens containing these (case-insensitive) are placeholders, not real paths.
+PLACEHOLDER_MARKERS = ("<", ">", "$", "path/to", "your")
+
+SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+KNOWN_SKILL_KEYS = {"name", "description", "version", "license", "allowed-tools", "metadata"}
+
+TOKEN_SPLIT = re.compile(r"""[\s'"()\[\]{},;`|]+""")
+PROJECT_FLAG_RE = re.compile(r"--project=([^\s'\"`,)\]]+)")
+
+errors: list[tuple[Path, int, str]] = []
+warnings: list[tuple[Path, int, str]] = []
+
+
+def error(path: Path, line: int, msg: str) -> None:
+    errors.append((path, line, msg))
+
+
+def warn(path: Path, line: int, msg: str) -> None:
+    warnings.append((path, line, msg))
+
+
+def rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+def parse_frontmatter(text: str):
+    """Return (frontmatter dict or None, error message or None)."""
+    m = re.match(r"\A---\r?\n(.*?)\r?\n---\r?\n", text, re.S)
+    if not m:
+        return None, "missing YAML frontmatter (--- ... ---) at the top of the file"
+    block = m.group(1)
+    try:
+        import yaml  # available on GitHub runners; optional locally
+        data = yaml.safe_load(block)
+        if not isinstance(data, dict):
+            return None, "frontmatter is not a YAML mapping"
+        return data, None
+    except ImportError:
+        pass
+    # Minimal fallback: top-level `key: value` and `key: >`/`key: |` folded blocks.
+    data: dict[str, str] = {}
+    key = None
+    folded: list[str] = []
+    for line in block.splitlines():
+        if line[:1] not in (" ", "\t") and ":" in line:
+            if key is not None:
+                data[key] = " ".join(folded).strip()
+            key, _, val = line.partition(":")
+            key = key.strip()
+            val = val.strip()
+            if val in (">", "|", ">-", "|-"):
+                folded = []
+            else:
+                data[key] = val
+                key = None
+        elif key is not None and line.strip():
+            folded.append(line.strip())
+    if key is not None:
+        data[key] = " ".join(folded).strip()
+    return data, None
+
+
+def code_tokens(path: Path):
+    """Yield (line_number, token) for tokens inside inline code spans and fenced blocks."""
+    in_fence = False
+    for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        chunks = [line] if in_fence else re.findall(r"`([^`]+)`", line)
+        for chunk in chunks:
+            for tok in TOKEN_SPLIT.split(chunk):
+                tok = tok.rstrip(".,:;")  # rstrip only: `.claude/...` keeps its leading dot
+                if tok:
+                    yield lineno, tok
+
+
+def is_placeholder(tok: str) -> bool:
+    low = tok.lower()
+    return any(marker in low for marker in PLACEHOLDER_MARKERS)
+
+
+def path_exists(tok: str, doc: Path) -> bool:
+    tok = tok.rstrip("/")
+    bases = [ROOT]
+    if doc.parent != ROOT:
+        bases.insert(0, doc.parent)  # skill docs may use paths relative to the skill dir
+    for base in bases:
+        if "*" in tok:
+            try:
+                if any(base.glob(tok)):
+                    return True
+            except (ValueError, NotImplementedError):
+                pass
+        elif (base / tok).exists():
+            return True
+    return False
+
+
+def check_paths(doc: Path) -> None:
+    seen: set[str] = set()
+    for lineno, tok in code_tokens(doc):
+        if tok in seen or is_placeholder(tok):
+            continue
+        if not (tok in TOP_LEVEL_FILES or tok.startswith(DIR_PREFIXES)):
+            continue
+        seen.add(tok)
+        if not path_exists(tok, doc):
+            error(doc, lineno, f"references `{tok}`, which does not exist in the repository")
+
+
+def check_project_flags(doc: Path) -> None:
+    text = doc.read_text()
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for proj in PROJECT_FLAG_RE.findall(line):
+            if proj in (".", "@.") or is_placeholder(proj):
+                continue
+            if not (ROOT / proj / "Project.toml").is_file():
+                error(doc, lineno, f"`--project={proj}` but {proj}/Project.toml does not exist")
+
+
+def check_size(doc: Path, max_lines: int, max_bytes: int | None = None) -> None:
+    n_lines = len(doc.read_text().splitlines())
+    n_bytes = doc.stat().st_size
+    if n_lines > max_lines:
+        error(doc, 1, f"{n_lines} lines exceeds the {max_lines}-line budget; move detail into a skill reference or delete it")
+    elif n_lines > 0.8 * max_lines:
+        warn(doc, 1, f"{n_lines} lines is close to the {max_lines}-line budget")
+    if max_bytes is not None and n_bytes > max_bytes:
+        error(doc, 1, f"{n_bytes} bytes exceeds the {max_bytes}-byte budget")
+
+
+def check_skill(skill_md: Path, seen_names: dict[str, Path]) -> None:
+    text = skill_md.read_text()
+    fm, err = parse_frontmatter(text)
+    if err:
+        error(skill_md, 1, err)
+        return
+
+    name = fm.get("name")
+    if not isinstance(name, str) or not name:
+        error(skill_md, 1, "frontmatter is missing a `name`")
+    else:
+        if len(name) > LIMITS["skill_name_len"]:
+            error(skill_md, 1, f"skill name is {len(name)} chars (max {LIMITS['skill_name_len']})")
+        if not SKILL_NAME_RE.match(name):
+            error(skill_md, 1, f"skill name `{name}` must be lowercase letters, digits, and hyphens")
+        if name != skill_md.parent.name:
+            error(skill_md, 1, f"skill name `{name}` does not match its directory `{skill_md.parent.name}`")
+        if name in seen_names:
+            error(skill_md, 1, f"skill name `{name}` is also used by {rel(seen_names[name])}")
+        else:
+            seen_names[name] = skill_md
+
+    desc = fm.get("description")
+    if not isinstance(desc, str) or not desc.strip():
+        error(skill_md, 1, "frontmatter is missing a `description`")
+    else:
+        desc = " ".join(desc.split())
+        if len(desc) > LIMITS["skill_desc_len"]:
+            error(skill_md, 1, f"description is {len(desc)} chars (max {LIMITS['skill_desc_len']})")
+        if len(desc) < LIMITS["skill_desc_min"]:
+            error(skill_md, 1, "description is too short to say what the skill does and when to use it")
+
+    for key in fm:
+        if key not in KNOWN_SKILL_KEYS:
+            warn(skill_md, 1, f"unexpected frontmatter key `{key}`")
+
+    check_size(skill_md, LIMITS["skill_lines"])
+
+    for ref in skill_md.parent.rglob("*.md"):
+        if ref != skill_md:
+            check_size(ref, LIMITS["reference_lines"])
+
+
+def check_duplicates(docs: list[Path]) -> None:
+    lines_by_content: dict[str, list[tuple[Path, int]]] = {}
+    for doc in docs:
+        for lineno, line in enumerate(doc.read_text().splitlines(), start=1):
+            norm = " ".join(line.split())
+            if len(norm) < LIMITS["dup_min_len"] or norm.startswith(("#", "```", "-->", "<!--")):
+                continue
+            lines_by_content.setdefault(norm, []).append((doc, lineno))
+    for norm, hits in lines_by_content.items():
+        files = {doc for doc, _ in hits}
+        if len(files) > 1:
+            doc, lineno = hits[0]
+            others = ", ".join(sorted(rel(d) for d in files if d != doc))
+            warn(doc, lineno, f"line duplicated verbatim in {others}: `{norm[:80]}`")
+
+
+def main() -> int:
+    memory_docs = [ROOT / f for f in MEMORY_FILES if (ROOT / f).is_file()]
+    skill_docs = sorted(p for g in SKILL_GLOBS for p in ROOT.glob(g))
+    reference_docs = sorted(
+        ref for s in skill_docs for ref in s.parent.rglob("*.md") if ref != s
+    )
+
+    if not memory_docs:
+        warn(ROOT / "CLAUDE.md", 1, "no CLAUDE.md or AGENTS.md found")
+
+    for doc in memory_docs:
+        check_size(doc, LIMITS["memory_lines"], LIMITS["memory_bytes"])
+    seen_names: dict[str, Path] = {}
+    for skill in skill_docs:
+        check_skill(skill, seen_names)
+
+    all_docs = memory_docs + skill_docs + reference_docs
+    for doc in all_docs:
+        check_paths(doc)
+        check_project_flags(doc)
+    check_duplicates(all_docs)
+
+    print(f"Checked {len(all_docs)} agent doc(s): " + ", ".join(rel(d) for d in all_docs))
+    for path, lineno, msg in warnings:
+        print(f"::warning file={rel(path)},line={lineno}::{msg}")
+        print(f"WARNING {rel(path)}:{lineno}: {msg}")
+    for path, lineno, msg in errors:
+        print(f"::error file={rel(path)},line={lineno}::{msg}")
+        print(f"ERROR {rel(path)}:{lineno}: {msg}")
+    if errors:
+        print(f"\n{len(errors)} error(s), {len(warnings)} warning(s)")
+        return 1
+    print(f"\nOK ({len(warnings)} warning(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/lint_agent_docs.py
+++ b/.github/scripts/lint_agent_docs.py
@@ -11,7 +11,8 @@ Deterministic checks that keep these files honest and slim:
 - long lines duplicated verbatim across files are reported (redundancy signal)
 
 Semantic checks (contradictions, redundancy in meaning, guideline adherence)
-are handled by the Claude review job in .github/workflows/agent-docs.yml.
+are out of scope here — review those by hand or with an agent when the docs
+change substantially.
 
 Errors fail CI (exit 1); warnings are annotated but do not fail.
 Runs with the Python 3 standard library only (PyYAML is used when available).

--- a/.github/scripts/lint_agent_docs.py
+++ b/.github/scripts/lint_agent_docs.py
@@ -11,7 +11,7 @@ Deterministic checks that keep these files honest and slim:
 - long lines duplicated verbatim across files are reported (redundancy signal)
 
 Semantic checks (contradictions, redundancy in meaning, guideline adherence)
-are handled by the Claude review job in .github/workflows/agent-docs.yml.
+are handled by the Claude PR review (.github/workflows/claude-pr-review.yml).
 
 Errors fail CI (exit 1); warnings are annotated but do not fail.
 Runs with the Python 3 standard library only (PyYAML is used when available).

--- a/.github/scripts/lint_agent_docs.py
+++ b/.github/scripts/lint_agent_docs.py
@@ -11,8 +11,7 @@ Deterministic checks that keep these files honest and slim:
 - long lines duplicated verbatim across files are reported (redundancy signal)
 
 Semantic checks (contradictions, redundancy in meaning, guideline adherence)
-are out of scope here — review those by hand or with an agent when the docs
-change substantially.
+are handled by the Claude review job in .github/workflows/agent-docs.yml.
 
 Errors fail CI (exit 1); warnings are annotated but do not fail.
 Runs with the Python 3 standard library only (PyYAML is used when available).

--- a/.github/scripts/lint_agent_docs.py
+++ b/.github/scripts/lint_agent_docs.py
@@ -17,6 +17,8 @@ Errors fail CI (exit 1); warnings are annotated but do not fail.
 Runs with the Python 3 standard library only (PyYAML is used when available).
 """
 
+from __future__ import annotations
+
 import re
 import sys
 from pathlib import Path
@@ -85,12 +87,16 @@ def parse_frontmatter(text: str):
     block = m.group(1)
     try:
         import yaml  # available on GitHub runners; optional locally
-        data = yaml.safe_load(block)
+    except ImportError:
+        yaml = None
+    if yaml is not None:
+        try:
+            data = yaml.safe_load(block)
+        except yaml.YAMLError as exc:
+            return None, f"frontmatter is not valid YAML: {' '.join(str(exc).split())}"
         if not isinstance(data, dict):
             return None, "frontmatter is not a YAML mapping"
         return data, None
-    except ImportError:
-        pass
     # Minimal fallback: top-level `key: value` and `key: >`/`key: |` folded blocks.
     data: dict[str, str] = {}
     key = None
@@ -155,6 +161,7 @@ def path_exists(tok: str, doc: Path) -> bool:
 def check_paths(doc: Path) -> None:
     seen: set[str] = set()
     for lineno, tok in code_tokens(doc):
+        tok = re.sub(r":\d+(-\d+)?$", "", tok)  # `src/rbm.jl:42` cites a line, not a path
         if tok in seen or is_placeholder(tok):
             continue
         if not (tok in TOP_LEVEL_FILES or tok.startswith(DIR_PREFIXES)):

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -31,6 +31,11 @@ jobs:
     name: Claude review of agent docs
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: read
     env:
       HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
     steps:
@@ -40,8 +45,8 @@ jobs:
       - name: Check whether agent docs changed
         id: changed
         run: |
-          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
-              | grep -qE '^(CLAUDE\.md|AGENTS\.md|\.claude/|\.agents/)'; then
+          if git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" \
+              | grep -qE '^(CLAUDE\.md|AGENTS\.md|\.claude/|\.agents/|\.github/workflows/agent-docs\.yml|\.github/scripts/lint_agent_docs\.py)'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -52,7 +57,7 @@ jobs:
         run: echo "::notice::ANTHROPIC_API_KEY is not available (fork PR or missing secret); skipping Claude review."
       - name: Review agent docs with Claude
         if: steps.changed.outputs.changed == 'true' && env.HAS_KEY == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@f1bd27ca5b54584506e40e17884d90bdaaa1a9b3 # v1.0.173
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
@@ -108,7 +113,13 @@ jobs:
           fi
           cat agent-docs-review.md >> "$GITHUB_STEP_SUMMARY"
           cat agent-docs-review.md
-          if grep -q '^VERDICT: FAIL' agent-docs-review.md; then
-            echo "::error::Claude review found blocking problems in the agent docs (see job summary)."
-            exit 1
-          fi
+          verdict=$(tail -n 1 agent-docs-review.md | tr -d '\r')
+          case "$verdict" in
+            "VERDICT: PASS")
+              echo "Claude review passed." ;;
+            "VERDICT: FAIL")
+              echo "::error::Claude review found blocking problems in the agent docs (see job summary)."
+              exit 1 ;;
+            *)
+              echo "::warning::agent-docs-review.md does not end with a VERDICT line; treating the review as inconclusive." ;;
+          esac

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -1,0 +1,114 @@
+# CI for the agent-instruction files: CLAUDE.md, AGENTS.md, and the skills
+# under .agents/ (and .claude/ if it appears).
+#
+# Two layers:
+#   1. `lint` — deterministic checks (.github/scripts/lint_agent_docs.py):
+#      size budgets, SKILL.md frontmatter rules, referenced repo paths exist,
+#      --project flags point at real Julia projects. Runs on every push/PR so
+#      renaming a source file that the docs mention breaks CI immediately.
+#   2. `claude-review` — semantic review with Claude on PRs that touch the
+#      agent docs: contradictions (between files and against the code),
+#      redundancy, context bloat, and adherence to the CLAUDE.md and Agent
+#      Skills best-practice guides. Skips cleanly when ANTHROPIC_API_KEY is
+#      not available (e.g. fork PRs).
+name: Agent docs
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  lint:
+    name: Lint agent docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - name: Lint CLAUDE.md, AGENTS.md and skills
+        run: python3 .github/scripts/lint_agent_docs.py
+  claude-review:
+    name: Claude review of agent docs
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+      - name: Check whether agent docs changed
+        id: changed
+        run: |
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+              | grep -qE '^(CLAUDE\.md|AGENTS\.md|\.claude/|\.agents/)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No agent docs changed; skipping Claude review."
+          fi
+      - name: Note when the API key is unavailable
+        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY != 'true'
+        run: echo "::notice::ANTHROPIC_API_KEY is not available (fork PR or missing secret); skipping Claude review."
+      - name: Review agent docs with Claude
+        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 40
+            --allowedTools "Read,Grep,Glob,LS,WebFetch,Write"
+          prompt: |
+            Review this repository's agent-instruction files ("agent docs"):
+            CLAUDE.md, AGENTS.md, and every SKILL.md plus its references/
+            under .agents/skills/ (and .claude/ if present).
+
+            First fetch these best-practice guides with WebFetch (if fetching
+            fails, proceed from your own knowledge of them):
+            - https://code.claude.com/docs/en/best-practices#write-an-effective-claude-md
+            - https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+
+            Then review the agent docs for:
+            1. Contradictions: statements that disagree with each other across
+               files, or with the actual repository. Spot-check commands, file
+               paths, and factual claims against the real repo tree and code.
+            2. Redundancy: substantial content maintained in two places. Small
+               overlaps (a shared test command) are fine; duplicated
+               explanations that can drift apart are not.
+            3. Context bloat: content that does not earn its place — generic
+               advice any model already knows, over-long prose, or detail that
+               belongs in a skill reference rather than CLAUDE.md.
+            4. Skill quality: each frontmatter description says what the skill
+               does AND when to use it; SKILL.md stays an overview with detail
+               pushed to references/; no deep reference chains.
+            5. Effectiveness per the fetched guides: concrete commands over
+               vague prose, currency, structure.
+
+            A deterministic linter (.github/scripts/lint_agent_docs.py) already
+            enforces size budgets, frontmatter constraints, and that referenced
+            paths exist — do not repeat those checks; focus on semantics.
+
+            Write your findings to agent-docs-review.md at the repository root:
+            - a one-paragraph summary
+            - a "Blocking" section: contradictions with the code or between
+              files, and heavy redundancy
+            - a "Suggestions" section: everything else
+            - final line exactly `VERDICT: FAIL` if there are blocking
+              findings, otherwise exactly `VERDICT: PASS`
+
+            Only mark FAIL for real, user-impacting problems; style preferences
+            belong under Suggestions.
+      - name: Enforce review verdict
+        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY == 'true'
+        run: |
+          if [ ! -f agent-docs-review.md ]; then
+            echo "::warning::Claude did not produce agent-docs-review.md; treating the review as inconclusive."
+            exit 0
+          fi
+          cat agent-docs-review.md >> "$GITHUB_STEP_SUMMARY"
+          cat agent-docs-review.md
+          if grep -q '^VERDICT: FAIL' agent-docs-review.md; then
+            echo "::error::Claude review found blocking problems in the agent docs (see job summary)."
+            exit 1
+          fi

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -1,16 +1,10 @@
 # CI for the agent-instruction files: CLAUDE.md, AGENTS.md, and the skills
 # under .agents/ (and .claude/ if it appears).
 #
-# Two layers:
-#   1. `lint` — deterministic checks (.github/scripts/lint_agent_docs.py):
-#      size budgets, SKILL.md frontmatter rules, referenced repo paths exist,
-#      --project flags point at real Julia projects. Runs on every push/PR so
-#      renaming a source file that the docs mention breaks CI immediately.
-#   2. `claude-review` — semantic review with Claude on PRs that touch the
-#      agent docs: contradictions (between files and against the code),
-#      redundancy, context bloat, and adherence to the CLAUDE.md and Agent
-#      Skills best-practice guides. Skips cleanly when ANTHROPIC_API_KEY is
-#      not available (e.g. fork PRs).
+# Deterministic checks (.github/scripts/lint_agent_docs.py): size budgets,
+# SKILL.md frontmatter rules, referenced repo paths exist, --project flags
+# point at real Julia projects. Runs on every push/PR so renaming a source
+# file that the docs mention breaks CI immediately.
 name: Agent docs
 on:
   push:
@@ -27,99 +21,3 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Lint CLAUDE.md, AGENTS.md and skills
         run: python3 .github/scripts/lint_agent_docs.py
-  claude-review:
-    name: Claude review of agent docs
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      id-token: write
-      pull-requests: read
-    env:
-      HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          fetch-depth: 0
-      - name: Check whether agent docs changed
-        id: changed
-        run: |
-          if git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" \
-              | grep -qE '^(CLAUDE\.md|AGENTS\.md|\.claude/|\.agents/|\.github/workflows/agent-docs\.yml|\.github/scripts/lint_agent_docs\.py)'; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No agent docs changed; skipping Claude review."
-          fi
-      - name: Note when the API key is unavailable
-        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY != 'true'
-        run: echo "::notice::ANTHROPIC_API_KEY is not available (fork PR or missing secret); skipping Claude review."
-      - name: Review agent docs with Claude
-        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY == 'true'
-        uses: anthropics/claude-code-action@f1bd27ca5b54584506e40e17884d90bdaaa1a9b3 # v1.0.173
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: |
-            --model claude-sonnet-5
-            --max-turns 40
-            --allowedTools "Read,Grep,Glob,LS,WebFetch,Write"
-          prompt: |
-            Review this repository's agent-instruction files ("agent docs"):
-            CLAUDE.md, AGENTS.md, and every SKILL.md plus its references/
-            under .agents/skills/ (and .claude/ if present).
-
-            First fetch these best-practice guides with WebFetch (if fetching
-            fails, proceed from your own knowledge of them):
-            - https://code.claude.com/docs/en/best-practices#write-an-effective-claude-md
-            - https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
-
-            Then review the agent docs for:
-            1. Contradictions: statements that disagree with each other across
-               files, or with the actual repository. Spot-check commands, file
-               paths, and factual claims against the real repo tree and code.
-            2. Redundancy: substantial content maintained in two places. Small
-               overlaps (a shared test command) are fine; duplicated
-               explanations that can drift apart are not.
-            3. Context bloat: content that does not earn its place — generic
-               advice any model already knows, over-long prose, or detail that
-               belongs in a skill reference rather than CLAUDE.md.
-            4. Skill quality: each frontmatter description says what the skill
-               does AND when to use it; SKILL.md stays an overview with detail
-               pushed to references/; no deep reference chains.
-            5. Effectiveness per the fetched guides: concrete commands over
-               vague prose, currency, structure.
-
-            A deterministic linter (.github/scripts/lint_agent_docs.py) already
-            enforces size budgets, frontmatter constraints, and that referenced
-            paths exist — do not repeat those checks; focus on semantics.
-
-            Write your findings to agent-docs-review.md at the repository root:
-            - a one-paragraph summary
-            - a "Blocking" section: contradictions with the code or between
-              files, and heavy redundancy
-            - a "Suggestions" section: everything else
-            - final line exactly `VERDICT: FAIL` if there are blocking
-              findings, otherwise exactly `VERDICT: PASS`
-
-            Only mark FAIL for real, user-impacting problems; style preferences
-            belong under Suggestions.
-      - name: Enforce review verdict
-        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY == 'true'
-        run: |
-          if [ ! -f agent-docs-review.md ]; then
-            echo "::warning::Claude did not produce agent-docs-review.md; treating the review as inconclusive."
-            exit 0
-          fi
-          cat agent-docs-review.md >> "$GITHUB_STEP_SUMMARY"
-          cat agent-docs-review.md
-          verdict=$(tail -n 1 agent-docs-review.md | tr -d '\r')
-          case "$verdict" in
-            "VERDICT: PASS")
-              echo "Claude review passed." ;;
-            "VERDICT: FAIL")
-              echo "::error::Claude review found blocking problems in the agent docs (see job summary)."
-              exit 1 ;;
-            *)
-              echo "::warning::agent-docs-review.md does not end with a VERDICT line; treating the review as inconclusive." ;;
-          esac

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -1,10 +1,18 @@
 # CI for the agent-instruction files: CLAUDE.md, AGENTS.md, and the skills
 # under .agents/ (and .claude/ if it appears).
 #
-# Deterministic checks (.github/scripts/lint_agent_docs.py): size budgets,
-# SKILL.md frontmatter rules, referenced repo paths exist, --project flags
-# point at real Julia projects. Runs on every push/PR so renaming a source
-# file that the docs mention breaks CI immediately.
+# Two layers:
+#   1. `lint` — deterministic checks (.github/scripts/lint_agent_docs.py):
+#      size budgets, SKILL.md frontmatter rules, referenced repo paths exist,
+#      --project flags point at real Julia projects. Runs on every push/PR so
+#      renaming a source file that the docs mention breaks CI immediately.
+#   2. `claude-review` — semantic review with Claude on PRs that touch the
+#      agent docs: contradictions (between files and against the code),
+#      redundancy, context bloat, and adherence to the CLAUDE.md and Agent
+#      Skills best-practice guides. Authenticates with the repo secret
+#      CLAUDE_CODE_OAUTH_TOKEN (a Claude subscription token from
+#      `claude setup-token`) and skips cleanly when it is not available
+#      (e.g. fork PRs).
 name: Agent docs
 on:
   push:
@@ -21,3 +29,99 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Lint CLAUDE.md, AGENTS.md and skills
         run: python3 .github/scripts/lint_agent_docs.py
+  claude-review:
+    name: Claude review of agent docs
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: read
+    env:
+      HAS_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+      - name: Check whether agent docs changed
+        id: changed
+        run: |
+          if git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" \
+              | grep -qE '^(CLAUDE\.md|AGENTS\.md|\.claude/|\.agents/|\.github/workflows/agent-docs\.yml|\.github/scripts/lint_agent_docs\.py)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No agent docs changed; skipping Claude review."
+          fi
+      - name: Note when the token is unavailable
+        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY != 'true'
+        run: echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not available (fork PR or missing secret); skipping Claude review."
+      - name: Review agent docs with Claude
+        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY == 'true'
+        uses: anthropics/claude-code-action@f1bd27ca5b54584506e40e17884d90bdaaa1a9b3 # v1.0.173
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 40
+            --allowedTools "Read,Grep,Glob,LS,WebFetch,Write"
+          prompt: |
+            Review this repository's agent-instruction files ("agent docs"):
+            CLAUDE.md, AGENTS.md, and every SKILL.md plus its references/
+            under .agents/skills/ (and .claude/ if present).
+
+            First fetch these best-practice guides with WebFetch (if fetching
+            fails, proceed from your own knowledge of them):
+            - https://code.claude.com/docs/en/best-practices#write-an-effective-claude-md
+            - https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+
+            Then review the agent docs for:
+            1. Contradictions: statements that disagree with each other across
+               files, or with the actual repository. Spot-check commands, file
+               paths, and factual claims against the real repo tree and code.
+            2. Redundancy: substantial content maintained in two places. Small
+               overlaps (a shared test command) are fine; duplicated
+               explanations that can drift apart are not.
+            3. Context bloat: content that does not earn its place — generic
+               advice any model already knows, over-long prose, or detail that
+               belongs in a skill reference rather than CLAUDE.md.
+            4. Skill quality: each frontmatter description says what the skill
+               does AND when to use it; SKILL.md stays an overview with detail
+               pushed to references/; no deep reference chains.
+            5. Effectiveness per the fetched guides: concrete commands over
+               vague prose, currency, structure.
+
+            A deterministic linter (.github/scripts/lint_agent_docs.py) already
+            enforces size budgets, frontmatter constraints, and that referenced
+            paths exist — do not repeat those checks; focus on semantics.
+
+            Write your findings to agent-docs-review.md at the repository root:
+            - a one-paragraph summary
+            - a "Blocking" section: contradictions with the code or between
+              files, and heavy redundancy
+            - a "Suggestions" section: everything else
+            - final line exactly `VERDICT: FAIL` if there are blocking
+              findings, otherwise exactly `VERDICT: PASS`
+
+            Only mark FAIL for real, user-impacting problems; style preferences
+            belong under Suggestions.
+      - name: Enforce review verdict
+        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY == 'true'
+        run: |
+          if [ ! -f agent-docs-review.md ]; then
+            echo "::warning::Claude did not produce agent-docs-review.md; treating the review as inconclusive."
+            exit 0
+          fi
+          cat agent-docs-review.md >> "$GITHUB_STEP_SUMMARY"
+          cat agent-docs-review.md
+          verdict=$(tail -n 1 agent-docs-review.md | tr -d '\r')
+          case "$verdict" in
+            "VERDICT: PASS")
+              echo "Claude review passed." ;;
+            "VERDICT: FAIL")
+              echo "::error::Claude review found blocking problems in the agent docs (see job summary)."
+              exit 1 ;;
+            *)
+              echo "::warning::agent-docs-review.md does not end with a VERDICT line; treating the review as inconclusive." ;;
+          esac

--- a/.github/workflows/agent-docs.yml
+++ b/.github/workflows/agent-docs.yml
@@ -1,18 +1,13 @@
 # CI for the agent-instruction files: CLAUDE.md, AGENTS.md, and the skills
 # under .agents/ (and .claude/ if it appears).
 #
-# Two layers:
-#   1. `lint` — deterministic checks (.github/scripts/lint_agent_docs.py):
-#      size budgets, SKILL.md frontmatter rules, referenced repo paths exist,
-#      --project flags point at real Julia projects. Runs on every push/PR so
-#      renaming a source file that the docs mention breaks CI immediately.
-#   2. `claude-review` — semantic review with Claude on PRs that touch the
-#      agent docs: contradictions (between files and against the code),
-#      redundancy, context bloat, and adherence to the CLAUDE.md and Agent
-#      Skills best-practice guides. Authenticates with the repo secret
-#      CLAUDE_CODE_OAUTH_TOKEN (a Claude subscription token from
-#      `claude setup-token`) and skips cleanly when it is not available
-#      (e.g. fork PRs).
+# Deterministic checks (.github/scripts/lint_agent_docs.py): size budgets,
+# SKILL.md frontmatter rules, referenced repo paths exist, --project flags
+# point at real Julia projects. Runs on every push/PR so renaming a source
+# file that the docs mention breaks CI immediately.
+#
+# Semantic review of these files (contradictions, redundancy, context
+# bloat) is part of the Claude PR review workflow (claude-pr-review.yml).
 name: Agent docs
 on:
   push:
@@ -29,99 +24,3 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Lint CLAUDE.md, AGENTS.md and skills
         run: python3 .github/scripts/lint_agent_docs.py
-  claude-review:
-    name: Claude review of agent docs
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      id-token: write
-      pull-requests: read
-    env:
-      HAS_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          fetch-depth: 0
-      - name: Check whether agent docs changed
-        id: changed
-        run: |
-          if git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" \
-              | grep -qE '^(CLAUDE\.md|AGENTS\.md|\.claude/|\.agents/|\.github/workflows/agent-docs\.yml|\.github/scripts/lint_agent_docs\.py)'; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No agent docs changed; skipping Claude review."
-          fi
-      - name: Note when the token is unavailable
-        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY != 'true'
-        run: echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not available (fork PR or missing secret); skipping Claude review."
-      - name: Review agent docs with Claude
-        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY == 'true'
-        uses: anthropics/claude-code-action@f1bd27ca5b54584506e40e17884d90bdaaa1a9b3 # v1.0.173
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model claude-sonnet-5
-            --max-turns 40
-            --allowedTools "Read,Grep,Glob,LS,WebFetch,Write"
-          prompt: |
-            Review this repository's agent-instruction files ("agent docs"):
-            CLAUDE.md, AGENTS.md, and every SKILL.md plus its references/
-            under .agents/skills/ (and .claude/ if present).
-
-            First fetch these best-practice guides with WebFetch (if fetching
-            fails, proceed from your own knowledge of them):
-            - https://code.claude.com/docs/en/best-practices#write-an-effective-claude-md
-            - https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
-
-            Then review the agent docs for:
-            1. Contradictions: statements that disagree with each other across
-               files, or with the actual repository. Spot-check commands, file
-               paths, and factual claims against the real repo tree and code.
-            2. Redundancy: substantial content maintained in two places. Small
-               overlaps (a shared test command) are fine; duplicated
-               explanations that can drift apart are not.
-            3. Context bloat: content that does not earn its place — generic
-               advice any model already knows, over-long prose, or detail that
-               belongs in a skill reference rather than CLAUDE.md.
-            4. Skill quality: each frontmatter description says what the skill
-               does AND when to use it; SKILL.md stays an overview with detail
-               pushed to references/; no deep reference chains.
-            5. Effectiveness per the fetched guides: concrete commands over
-               vague prose, currency, structure.
-
-            A deterministic linter (.github/scripts/lint_agent_docs.py) already
-            enforces size budgets, frontmatter constraints, and that referenced
-            paths exist — do not repeat those checks; focus on semantics.
-
-            Write your findings to agent-docs-review.md at the repository root:
-            - a one-paragraph summary
-            - a "Blocking" section: contradictions with the code or between
-              files, and heavy redundancy
-            - a "Suggestions" section: everything else
-            - final line exactly `VERDICT: FAIL` if there are blocking
-              findings, otherwise exactly `VERDICT: PASS`
-
-            Only mark FAIL for real, user-impacting problems; style preferences
-            belong under Suggestions.
-      - name: Enforce review verdict
-        if: steps.changed.outputs.changed == 'true' && env.HAS_KEY == 'true'
-        run: |
-          if [ ! -f agent-docs-review.md ]; then
-            echo "::warning::Claude did not produce agent-docs-review.md; treating the review as inconclusive."
-            exit 0
-          fi
-          cat agent-docs-review.md >> "$GITHUB_STEP_SUMMARY"
-          cat agent-docs-review.md
-          verdict=$(tail -n 1 agent-docs-review.md | tr -d '\r')
-          case "$verdict" in
-            "VERDICT: PASS")
-              echo "Claude review passed." ;;
-            "VERDICT: FAIL")
-              echo "::error::Claude review found blocking problems in the agent docs (see job summary)."
-              exit 1 ;;
-            *)
-              echo "::warning::agent-docs-review.md does not end with a VERDICT line; treating the review as inconclusive." ;;
-          esac

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -58,12 +58,17 @@ jobs:
             PR NUMBER: ${{ github.event.pull_request.number }}
 
             First, reconcile earlier runs of this review: list the PR's
-            review threads (`gh api graphql` with the pullRequest
-            reviewThreads query), and for unresolved threads posted by a
-            previous run of this workflow (bot-authored), check whether the
-            current code addresses them. Resolve the addressed ones with the
-            resolveReviewThread GraphQL mutation, and do not post duplicates
-            of comments that are still valid and unresolved.
+            review threads including their replies (`gh api graphql` with
+            the pullRequest reviewThreads query). For each unresolved thread
+            posted by a previous run of this workflow (bot-authored):
+            - If the current code addresses it, or the author's reply
+              convincingly rebuts it, resolve the thread with the
+              resolveReviewThread GraphQL mutation.
+            - If the author replied but you remain unconvinced, reply back
+              in the thread (addPullRequestReviewThreadReply mutation)
+              explaining briefly why the finding stands.
+            Do not post duplicates of comments that are still valid and
+            unresolved.
 
             Then review this pull request. Read the full diff (`gh pr diff`)
             and enough of the surrounding code to judge each change in

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,14 +1,15 @@
 # Advisory Claude review of every pull request.
 #
 # Reviews the full PR diff and posts inline review comments for real
-# findings (bugs, correctness, security). It is advisory only: the job
-# never fails because of review findings, so it cannot block a merge.
-# Authenticates with the CLAUDE_CODE_OAUTH_TOKEN repo secret (a Claude
-# subscription token from `claude setup-token`) and skips cleanly when
-# the secret is unavailable (e.g. fork PRs).
+# findings (bugs, correctness, security). When the PR touches the
+# agent-instruction files (CLAUDE.md, AGENTS.md, skills), it additionally
+# reviews those for contradictions with the code, redundancy, and context
+# bloat — complementing the deterministic linter in agent-docs.yml.
 #
-# The agent-docs workflow has its own, blocking Claude review for
-# CLAUDE.md/AGENTS.md/skills; this one covers everything else.
+# It is advisory only: the job never fails because of review findings, so
+# it cannot block a merge. Authenticates with the CLAUDE_CODE_OAUTH_TOKEN
+# repo secret (a Claude subscription token from `claude setup-token`) and
+# skips cleanly when the secret is unavailable (e.g. fork PRs).
 name: Claude PR review
 on:
   pull_request:
@@ -46,7 +47,7 @@ jobs:
           claude_args: |
             --model claude-sonnet-5
             --max-turns 60
-            --allowedTools "Read,Grep,Glob,LS,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Read,Grep,Glob,LS,WebFetch,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),mcp__github_inline_comment__create_inline_comment"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -59,19 +60,34 @@ jobs:
             resolveReviewThread GraphQL mutation, and do not post duplicates
             of comments that are still valid and unresolved.
 
-            Then review this pull request. Read the full diff (`gh pr diff`) and
-            enough of the surrounding code to judge each change in context.
-            This is a Julia package for Restricted Boltzmann Machines; pay
-            attention to array shape conventions (layer dims first, batch
-            dim last), type-genericity (code must stay generic over array
-            backends, e.g. CUDA), and numerical correctness of any
-            math-sensitive change.
+            Then review this pull request. Read the full diff (`gh pr diff`)
+            and enough of the surrounding code to judge each change in
+            context. This is a Julia package for Restricted Boltzmann
+            Machines; pay attention to array shape conventions (layer dims
+            first, batch dim last), type-genericity (code must stay generic
+            over array backends, e.g. CUDA), and numerical correctness of
+            any math-sensitive change.
 
             Look for real problems only:
             - bugs and logic errors, wrong edge-case behavior
             - correctness of math/statistics changes
             - API breakage or behavior changes not reflected in tests/docs
             - security issues (e.g. in CI workflow changes)
+
+            If the diff touches agent-instruction files (CLAUDE.md,
+            AGENTS.md, or anything under .agents/ or .claude/), also review
+            those for: contradictions with each other or with the actual
+            repository (spot-check commands, paths, and factual claims
+            against the code); substantial redundancy that can drift apart;
+            context bloat (content that does not earn its place); and skill
+            frontmatter descriptions that fail to say what the skill does
+            and when to use it. Consult the best-practice guides with
+            WebFetch if helpful:
+            https://code.claude.com/docs/en/best-practices and
+            https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+            A deterministic linter (.github/scripts/lint_agent_docs.py)
+            already enforces sizes, frontmatter constraints, and path
+            existence — focus on semantics.
 
             Post each finding as an inline comment on the relevant line
             using mcp__github_inline_comment__create_inline_comment, with a

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,15 +1,20 @@
-# Advisory Claude review of every pull request.
+# Claude review of every pull request.
 #
 # Reviews the full PR diff and posts inline review comments for real
-# findings (bugs, correctness, security). When the PR touches the
+# findings (bugs, correctness, security), then submits a review verdict:
+# approve when convinced the PR is sound, request changes on serious
+# confirmed problems, comment-only otherwise. When the PR touches the
 # agent-instruction files (CLAUDE.md, AGENTS.md, skills), it additionally
 # reviews those for contradictions with the code, redundancy, and context
 # bloat — complementing the deterministic linter in agent-docs.yml.
 #
-# It is advisory only: the job never fails because of review findings, so
-# it cannot block a merge. Authenticates with the CLAUDE_CODE_OAUTH_TOKEN
-# repo secret (a Claude subscription token from `claude setup-token`) and
-# skips cleanly when the secret is unavailable (e.g. fork PRs).
+# The job itself never fails because of review findings; the verdict is
+# expressed through the PR review state. Approving requires the repo
+# setting "Allow GitHub Actions to create and approve pull requests"
+# (Settings -> Actions -> General); without it, approval falls back to a
+# comment. Authenticates with the CLAUDE_CODE_OAUTH_TOKEN repo secret (a
+# Claude subscription token from `claude setup-token`) and skips cleanly
+# when the secret is unavailable (e.g. fork PRs).
 name: Claude PR review
 on:
   pull_request:
@@ -47,7 +52,7 @@ jobs:
           claude_args: |
             --model claude-sonnet-5
             --max-turns 60
-            --allowedTools "Read,Grep,Glob,LS,WebFetch,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Read,Grep,Glob,LS,WebFetch,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),mcp__github_inline_comment__create_inline_comment"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -93,7 +98,23 @@ jobs:
             using mcp__github_inline_comment__create_inline_comment, with a
             short explanation and, where possible, a concrete suggestion.
 
-            This review is advisory. Be conservative: do not comment on
-            style, formatting, or preferences; do not restate what the diff
-            does; if you find nothing significant, post no comments at all.
-            Do not approve, request changes, or merge.
+            Be conservative about findings: do not comment on style,
+            formatting, or preferences; do not restate what the diff does;
+            if you find nothing significant, post no inline comments.
+
+            Finally, submit a review verdict with `gh pr review`:
+            - If you are convinced the PR is correct, complete, and safe,
+              approve it: `gh pr review --approve --body "..."` with a
+              one-paragraph justification of what you checked. If approval
+              is rejected for permission reasons, fall back to
+              `gh pr review --comment --body "..."` with the same text.
+            - If you confirmed a serious problem (a real bug, data
+              corruption, security issue, or broken API), request changes:
+              `gh pr review --request-changes --body "..."` summarizing the
+              blocking findings. Reserve this for confirmed, consequential
+              problems — never for uncertainty or taste.
+            - Otherwise (minor or uncertain findings only), submit
+              `gh pr review --comment --body "..."` with a short summary.
+            On re-runs after new commits, submit a fresh verdict; an
+            approval supersedes your earlier request-changes once the
+            problems are fixed. Never merge the PR.

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,83 @@
+# Advisory Claude review of every pull request.
+#
+# Reviews the full PR diff and posts inline review comments for real
+# findings (bugs, correctness, security). It is advisory only: the job
+# never fails because of review findings, so it cannot block a merge.
+# Authenticates with the CLAUDE_CODE_OAUTH_TOKEN repo secret (a Claude
+# subscription token from `claude setup-token`) and skips cleanly when
+# the secret is unavailable (e.g. fork PRs).
+#
+# The agent-docs workflow has its own, blocking Claude review for
+# CLAUDE.md/AGENTS.md/skills; this one covers everything else.
+name: Claude PR review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+permissions:
+  contents: read
+concurrency:
+  group: claude-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  review:
+    name: Claude review
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    env:
+      HAS_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+    steps:
+      - name: Note when the token is unavailable
+        if: env.HAS_KEY != 'true'
+        run: echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not available (fork PR or missing secret); skipping Claude review."
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        if: env.HAS_KEY == 'true'
+        with:
+          fetch-depth: 0
+      - name: Review pull request with Claude
+        if: env.HAS_KEY == 'true'
+        uses: anthropics/claude-code-action@f1bd27ca5b54584506e40e17884d90bdaaa1a9b3 # v1.0.173
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 60
+            --allowedTools "Read,Grep,Glob,LS,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),mcp__github_inline_comment__create_inline_comment"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            First, reconcile earlier runs of this review: list the PR's
+            review threads (`gh api graphql` with the pullRequest
+            reviewThreads query), and for unresolved threads posted by a
+            previous run of this workflow (bot-authored), check whether the
+            current code addresses them. Resolve the addressed ones with the
+            resolveReviewThread GraphQL mutation, and do not post duplicates
+            of comments that are still valid and unresolved.
+
+            Then review this pull request. Read the full diff (`gh pr diff`) and
+            enough of the surrounding code to judge each change in context.
+            This is a Julia package for Restricted Boltzmann Machines; pay
+            attention to array shape conventions (layer dims first, batch
+            dim last), type-genericity (code must stay generic over array
+            backends, e.g. CUDA), and numerical correctness of any
+            math-sensitive change.
+
+            Look for real problems only:
+            - bugs and logic errors, wrong edge-case behavior
+            - correctness of math/statistics changes
+            - API breakage or behavior changes not reflected in tests/docs
+            - security issues (e.g. in CI workflow changes)
+
+            Post each finding as an inline comment on the relevant line
+            using mcp__github_inline_comment__create_inline_comment, with a
+            short explanation and, where possible, a concrete suggestion.
+
+            This review is advisory. Be conservative: do not comment on
+            style, formatting, or preferences; do not restate what the diff
+            does; if you find nothing significant, post no comments at all.
+            Do not approve, request changes, or merge.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,3 +51,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --model claude-sonnet-5
+            --append-system-prompt "Repo policy: never merge pull requests or enable auto-merge — merging is reserved for the repo owner. When working on a PR, strive to earn the automated Claude reviewer's approval: address its review findings with fixes, or reply in the review threads with reasoning when a finding is mistaken."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,11 @@ on:
     types: [opened]
 permissions:
   contents: read
+# Serialize (queue, don't cancel) concurrent @claude runs on the same
+# issue/PR, so parallel mentions can't push to the same branch at once.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
 jobs:
   claude:
     name: Claude
@@ -51,4 +56,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --model claude-sonnet-5
-            --append-system-prompt "Repo policy: never merge pull requests or enable auto-merge — merging is reserved for the repo owner. When working on a PR, strive to earn the automated Claude reviewer's approval: address its review findings with fixes, or reply in the review threads with reasoning when a finding is mistaken."
+            --append-system-prompt "Repo policy: never merge pull requests or enable auto-merge — merging is reserved for the repo owner. When working on a PR, strive to earn the automated Claude reviewer's approval: address its review findings with fixes, or reply in the review threads with reasoning when a finding is mistaken. Reply in every review thread on your PR (the fixing commit or your reasoning) before considering the work done, and do not resolve review threads yourself — the reviewer resolves them once convinced."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,53 @@
+# Interactive Claude: responds when @claude is mentioned in an issue, a PR
+# comment, a review, or a reply to a review thread. This is what lets a
+# reply like "@claude this is fixed, resolve it" or "@claude review" get a
+# response, and lets Claude push fix commits to a PR branch when asked.
+#
+# Only mentions from the repo owner, members, and collaborators trigger it,
+# so arbitrary commenters on a public repo cannot spend the quota or drive
+# the agent. Authenticates with the CLAUDE_CODE_OAUTH_TOKEN repo secret.
+name: Claude
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened]
+permissions:
+  contents: read
+jobs:
+  claude:
+    name: Claude
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    env:
+      HAS_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+    steps:
+      - name: Note when the token is unavailable
+        if: env.HAS_KEY != 'true'
+        run: echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not available; skipping."
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        if: env.HAS_KEY == 'true'
+        with:
+          fetch-depth: 0
+      - name: Run Claude
+        if: env.HAS_KEY == 'true'
+        uses: anthropics/claude-code-action@f1bd27ca5b54584506e40e17884d90bdaaa1a9b3 # v1.0.173
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This is a Julia package (RestrictedBoltzmannMachines.jl). Julia is installed via
 
 ### Quick reference
 
-Commands for common tasks are documented in `.claude/CLAUDE.md` under "Common Commands". Key commands:
+Commands for common tasks are documented in `CLAUDE.md` under "Common Commands". Key commands:
 
 - **Run all tests:** `julia --project=. -e 'using Pkg; Pkg.test()'`
 - **Run a single test file:** `julia --project=test test/<file>.jl`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,12 @@ Tests in `test/runtests.jl` are organized as independent modules (each wrapped i
 
 GPU compatibility is tested without GPU hardware in `test/jlarrays.jl`, using JLArrays with `allowscalar(false)`. Do not commit tests that require a physical GPU (GitHub CI has none); run those locally only.
 
+## Pull Requests
+
+Every PR receives an automated Claude review (`.github/workflows/claude-pr-review.yml`) that posts inline comments and ends with a review verdict: approve, request changes, or comment. When authoring a PR, treat the reviewer's approval as the default bar before merge: address its findings by pushing fixes, or reply in the review threads with reasoning if a finding is mistaken — the reviewer re-runs on every push, and a fresh verdict supersedes the previous one.
+
+Never merge a PR or enable auto-merge. Merging happens only when the repo owner clicks merge on GitHub or explicitly instructs it.
+
 ## Releasing a new version
 
 During development the version in Project.toml carries a `-DEV` suffix (e.g. `5.4.0-DEV`), and changes accumulate under an `## Unreleased` section in CHANGELOG.md. To release:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@ GPU compatibility is tested without GPU hardware in `test/jlarrays.jl`, using JL
 
 Every PR receives an automated Claude review (`.github/workflows/claude-pr-review.yml`) that posts inline comments and ends with a review verdict: approve, request changes, or comment. When authoring a PR, treat the reviewer's approval as the default bar before merge: address its findings by pushing fixes, or reply in the review threads with reasoning if a finding is mistaken — the reviewer re-runs on every push, and a fresh verdict supersedes the previous one.
 
+Reply in every review thread on your PR before considering the work done: either point at the commit that addresses the finding, or explain why it is mistaken. Do not resolve review threads yourself — the reviewer resolves a thread once convinced (by the fix or by your reply), and replies back when not.
+
 Never merge a PR or enable auto-merge. Merging happens only when the repo owner clicks merge on GitHub or explicitly instructs it.
 
 ## Releasing a new version


### PR DESCRIPTION
Adds CI to keep agent-instruction files (CLAUDE.md, AGENTS.md, and SKILL.md files under .agents/ and .claude/) honest, slim, and up-to-date with the repository, plus Claude-powered review automation for all PRs.

## Changes

- **`.github/scripts/lint_agent_docs.py`** — New deterministic linter that enforces:
  - Size budgets (CLAUDE.md/AGENTS.md ≤250 lines/16KB; SKILL.md ≤500 lines; references ≤1000 lines)
  - SKILL.md frontmatter rules per the Agent Skills spec (name format, description length, required keys)
  - All repo paths mentioned in docs actually exist (staleness check); `file.jl:42`-style line citations are supported
  - `--project=` flags point to real Julia projects with Project.toml
  - Detection of long lines duplicated verbatim across files (redundancy signal)
  - Errors fail CI, warnings are annotated

- **`.github/workflows/agent-docs.yml`** — Runs the linter on every push to master and every PR (blocking).

- **`.github/workflows/claude-pr-review.yml`** — Claude review of every non-draft PR (model `claude-sonnet-5`): reviews the full diff for bugs, correctness, math/shape issues, and CI security, posting findings as inline comments, then submits a review verdict — **approve** with justification when convinced, **request changes** only for confirmed consequential problems, comment summary otherwise. On re-runs a fresh verdict supersedes the previous one. When the diff touches agent docs, the same run also reviews them semantically (contradictions with the code, redundancy, context bloat, skill description quality). Each run reconciles threads from previous runs, resolving those addressed by new commits. The job itself never fails CI; the verdict lives in the PR review state. Runs on every push to a PR, with a concurrency group cancelling superseded runs.

- **`.github/workflows/claude.yml`** — Interactive `@claude` tag mode in issues, PR comments, reviews, and review-thread replies; gated to mentions from the owner, members, and collaborators, with the repo merge policy appended to its system prompt.

- **CLAUDE.md** — New "Pull Requests" section documenting the workflow policy: PR-authoring agents should treat the Claude reviewer's approval as the default pre-merge bar (push fixes or argue back in review threads), and must never merge or enable auto-merge — merging is reserved for the repo owner (GitHub UI or explicit instruction).

- **Minor doc updates** — Fixed stale references in `.agents/skills/restricted-boltzmann-machines-jl/references/architecture.md` and `AGENTS.md` to reflect current file organization (the pre-fix `AGENTS.md` reference to `.claude/CLAUDE.md` would have failed this very linter).

## Implementation Notes

- The linter uses only the Python 3 standard library (PyYAML is used when available for stricter YAML parsing; otherwise a minimal frontmatter parser is used); placeholder detection (`<sha>`, `$VAR`, `path/to/...`, `ext/YourExt.jl`) prevents false positives on template text
- The Claude workflows authenticate with the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (subscription token from `claude setup-token`) and skip cleanly when it is unavailable (e.g. fork PRs); the action is pinned to an immutable commit SHA
- The Claude workflows cannot execute on this PR itself: `claude-code-action` self-skips on PRs whose workflow files differ from the default branch (anti-tampering). They start executing on the first PR after this one merges

https://claude.ai/code/session_01KgRbFK1rTR11VtmuCMbYTi