### PR TITLE
Skill: after successful registration, suggest the next -DEV bump PR

### DIFF
--- a/.claude/skills/register-new-version/SKILL.md
+++ b/.claude/skills/register-new-version/SKILL.md
@@ -43,7 +43,7 @@ Before anything else, determine the right version number and confirm it with the
 
 5. **Tag and GitHub release.** Once the registry PR merges, TagBot creates the `vX.Y.Z` tag at the registered commit and the GitHub release (with the notes) automatically — no action needed. Afterwards the `release-X.Y.Z` branch is redundant (the tag protects the commit) and may be deleted.
 
-6. **Start the next cycle.** Once the version is successfully registered in General (registry PR merged, tag created), always suggest to the user following up with a new PR that bumps Project.toml to the next `-DEV` version (usually `X.Y+1.0-DEV`) and adds a fresh `## Unreleased` section to CHANGELOG.md, so development commits never accumulate under a released version number.
+6. **Start the next cycle.** Once the version is successfully registered in General (registry PR merged, tag created), always suggest that the user follow up with a new PR that bumps Project.toml to the next `-DEV` version and adds a fresh `## Unreleased` section to CHANGELOG.md, so development commits never accumulate under a released version number. (E.g. after releasing `5.7.0`, bump to `5.7.1-DEV`, or `5.8.0-DEV` if new features are anticipated — the choice is only a hint, since the actual release number is re-derived from the changes when releasing; see the semver section above.)
 
 A condensed human-facing copy of this procedure lives in `docs/src/developer/testing.md`; keep it in sync with this skill.
 

--- a/.claude/skills/register-new-version/SKILL.md
+++ b/.claude/skills/register-new-version/SKILL.md
@@ -43,7 +43,7 @@ Before anything else, determine the right version number and confirm it with the
 
 5. **Tag and GitHub release.** Once the registry PR merges, TagBot creates the `vX.Y.Z` tag at the registered commit and the GitHub release (with the notes) automatically — no action needed. Afterwards the `release-X.Y.Z` branch is redundant (the tag protects the commit) and may be deleted.
 
-6. **Start the next cycle.** When starting work on the next version, bump Project.toml to the next `-DEV` version and add a fresh `## Unreleased` section to CHANGELOG.md.
+6. **Start the next cycle.** Once the version is successfully registered in General (registry PR merged, tag created), always suggest to the user following up with a new PR that bumps Project.toml to the next `-DEV` version (usually `X.Y+1.0-DEV`) and adds a fresh `## Unreleased` section to CHANGELOG.md, so development commits never accumulate under a released version number.
 
 A condensed human-facing copy of this procedure lives in `docs/src/developer/testing.md`; keep it in sync with this skill.
 

--- a/docs/src/developer/testing.md
+++ b/docs/src/developer/testing.md
@@ -54,8 +54,11 @@ During development the version in `Project.toml` carries a `-DEV` suffix
    master commit, and comment on issue #124 again to re-trigger the
    registration pointing at the new branch. Once the registry PR has merged
    and TagBot has tagged, the `release-X.Y.Z` branch may be deleted.
-5. When starting work on the next version, bump `Project.toml` to the next
-   `-DEV` version and add a fresh `## Unreleased` section to `CHANGELOG.md`.
+5. Right after the release (registry PR merged, tag created), follow up with
+   a new PR that bumps `Project.toml` to the next `-DEV` version (e.g.
+   `5.7.1-DEV` after releasing `5.7.0`, or `5.8.0-DEV` if new features are
+   anticipated) and adds a fresh `## Unreleased` section to `CHANGELOG.md`,
+   so development commits never accumulate under a released version number.
 
 The canonical, more detailed version of this procedure lives in the
 `register-new-version` skill at


### PR DESCRIPTION
One-line addition to the `register-new-version` skill: once a version is successfully registered in the General registry (registry PR merged, tag created), the skill now instructs to always suggest a follow-up PR bumping Project.toml to the next `-DEV` version and adding a fresh `## Unreleased` section to CHANGELOG.md, so development commits never accumulate under a released version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y45mgEw1sVskqGUozXCc9V

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y45mgEw1sVskqGUozXCc9V)_