### PR TITLE
Refine Claude PR reviewer guidance on suggestion blocks

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -102,6 +102,15 @@ jobs:
             Post each finding as an inline comment on the relevant line
             using mcp__github_inline_comment__create_inline_comment, with a
             short explanation and, where possible, a concrete suggestion.
+            Only include a ```suggestion block when the replacement text is
+            the exact, complete replacement for the anchored lines of the
+            file the comment is on — GitHub applies it verbatim to those
+            lines with one click. If the fix belongs in a different file
+            than the one you are commenting on, describe it in prose
+            instead; never put another file's text in a suggestion block.
+            When a finding spans two files (a change here contradicts text
+            there), prefer anchoring the comment to the file that needs the
+            edit, when that file is part of the diff.
 
             Be conservative about findings: do not comment on style,
             formatting, or preferences; do not restate what the diff does;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- The Claude PR review workflow now instructs the reviewer to only emit a GitHub ```suggestion block when the replacement text fits the exact anchored lines of the commented file, describing cross-file fixes in prose instead, and to prefer anchoring cross-file findings on the file that needs the edit. Previously the reviewer could post a one-click-applyable suggestion containing another file's text ([#128](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/128)).
+
 ## 5.7.0
 
 - Fixed `xReLU(layer::nsReLU)`, which built the fixed `γ = 1` array with `ones(size(layer.θ))`, always returning a host `Array{Float64}`. Since this conversion backs `energies`, `cgfs`, `∂cgfs`, `sample_from_inputs` and the other moment functions of `nsReLU`, it promoted the entire hidden-layer computation to `Float64` and, on GPU, forced a host allocation plus a host→device transfer on every call. It now uses `one.(layer.θ)`, preserving both eltype and device ([#119](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/119)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-- The Claude PR review workflow now instructs the reviewer to only emit a GitHub ```` ```suggestion ```` block when the replacement text fits the exact anchored lines of the commented file, describing cross-file fixes in prose instead, and to prefer anchoring cross-file findings on the file that needs the edit. Previously the reviewer could post a one-click-applyable suggestion containing another file's text ([#128](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/128)).
-
 ## 5.7.0
 
 - Fixed `xReLU(layer::nsReLU)`, which built the fixed `γ = 1` array with `ones(size(layer.θ))`, always returning a host `Array{Float64}`. Since this conversion backs `energies`, `cgfs`, `∂cgfs`, `sample_from_inputs` and the other moment functions of `nsReLU`, it promoted the entire hidden-layer computation to `Float64` and, on GPU, forced a host allocation plus a host→device transfer on every call. It now uses `one.(layer.θ)`, preserving both eltype and device ([#119](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/119)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
-- The Claude PR review workflow now instructs the reviewer to only emit a GitHub ```suggestion block when the replacement text fits the exact anchored lines of the commented file, describing cross-file fixes in prose instead, and to prefer anchoring cross-file findings on the file that needs the edit. Previously the reviewer could post a one-click-applyable suggestion containing another file's text ([#128](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/128)).
+- The Claude PR review workflow now instructs the reviewer to only emit a GitHub ```` ```suggestion ```` block when the replacement text fits the exact anchored lines of the commented file, describing cross-file fixes in prose instead, and to prefer anchoring cross-file findings on the file that needs the edit. Previously the reviewer could post a one-click-applyable suggestion containing another file's text ([#128](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/128)).
 
 ## 5.7.0
 


### PR DESCRIPTION
## Summary

This PR clarifies the instructions for the Claude PR reviewer workflow to prevent it from posting GitHub suggestion blocks that contain code from files other than the one being commented on. Such cross-file suggestions cannot be applied by GitHub's one-click mechanism and create confusion.

## Changes

- **`.github/workflows/claude-pr-review.yml`**: Enhanced the reviewer prompt with explicit guidance:
  - Only emit a ```suggestion block when the replacement text is the exact, complete replacement for the anchored lines of the commented file
  - Describe fixes that belong in different files in prose instead of suggestion blocks
  - When a finding spans two files, prefer anchoring the comment to the file that needs the edit (if it's part of the diff)

- **`CHANGELOG.md`**: Added an `Unreleased` section documenting this improvement, referencing issue #128

## Implementation Details

The new guidance prevents a class of unhelpful suggestions where the reviewer would post a one-click-applyable suggestion block containing another file's text. GitHub applies suggestion blocks verbatim to the anchored lines, so cross-file suggestions are not actionable. The updated instructions ensure the reviewer either:
1. Posts a suggestion block only when it applies to the exact lines of the file being commented on, or
2. Describes the fix in prose for cross-file issues, anchoring to the file that needs editing when possible

https://claude.ai/code/session_019GtVpXVvp4HsijQRkTNVo1