### PR TITLE
Emit a notice when the Claude review self-skips on workflow-editing PRs

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -44,6 +44,13 @@ jobs:
         if: env.HAS_KEY == 'true'
         with:
           fetch-depth: 0
+      - name: Note when this PR modifies the review workflow itself
+        if: env.HAS_KEY == 'true'
+        run: |
+          if git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" \
+              | grep -q '^\.github/workflows/claude-pr-review\.yml$'; then
+            echo "::notice::Claude review self-skips on this PR: it modifies the review workflow itself, and claude-code-action only runs the workflow version already on the default branch (anti-tampering). The green check below means skipped, not reviewed. The review runs normally on PRs that leave this file unchanged."
+          fi
       - name: Review pull request with Claude
         if: env.HAS_KEY == 'true'
         uses: anthropics/claude-code-action@f1bd27ca5b54584506e40e17884d90bdaaa1a9b3 # v1.0.173


### PR DESCRIPTION
## Summary

`claude-code-action` refuses to execute on PRs whose workflow file differs from the version on the default branch (anti-tampering), exiting green in ~25 seconds. As seen on #126 and #129, that green check is easy to misread as "reviewed, found nothing."

This adds a small step to `.github/workflows/claude-pr-review.yml`, between checkout and the action, that detects when the PR modifies the review workflow itself and emits a `::notice::` annotation explaining that the review self-skips on such PRs and why — so the Actions summary states what happened instead of a silent pass.

## Notes

- The step runs only when the token is present (`HAS_KEY == 'true'`, same gate as checkout, which it needs for the `git diff`), and uses `$GITHUB_BASE_REF` rather than expression interpolation, consistent with the rest of the workflow.
- **This PR demonstrates its own change:** since it modifies the workflow file, its own `Claude review` run executes the new step and should show the notice — that's the acceptance check.
- Touches a different hunk of the same file as #129 (which edits the prompt), so the two merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ww7NmnFv7P8MkrSKXtPGCa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ww7NmnFv7P8MkrSKXtPGCa)_