### PR TITLE
Handle workflow self-skip with PR comment explaining escape hatch

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -8,6 +8,14 @@
 # reviews those for contradictions with the code, redundancy, and context
 # bloat — complementing the deterministic linter in agent-docs.yml.
 #
+# claude-code-action self-skips when this file differs from the version
+# on the default branch (anti-tampering), so PRs that modify this
+# workflow get no automated review. On such PRs the job instead posts a
+# PR comment explaining that, including the escape hatch: commenting
+# "@claude review this PR" still triggers a review, because claude.yml
+# runs from the default branch on comment events and always passes the
+# validation.
+#
 # The job itself never fails because of review findings; the verdict is
 # expressed through the PR review state. Approving requires the repo
 # setting "Allow GitHub Actions to create and approve pull requests"
@@ -44,12 +52,26 @@ jobs:
         if: env.HAS_KEY == 'true'
         with:
           fetch-depth: 0
-      - name: Note when this PR modifies the review workflow itself
+      - name: Explain when this PR modifies the review workflow itself
         if: env.HAS_KEY == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" \
               | grep -q '^\.github/workflows/claude-pr-review\.yml$'; then
-            echo "::notice::Claude review self-skips on this PR: it modifies the review workflow itself, and claude-code-action only runs the workflow version already on the default branch (anti-tampering). The green check below means skipped, not reviewed. The review runs normally on PRs that leave this file unchanged."
+            echo "::notice::Claude review self-skips on this PR: it modifies the review workflow itself, and claude-code-action only runs the workflow version already on the default branch (anti-tampering). The green check below means skipped, not reviewed. Comment '@claude review this PR' to request a review manually."
+            marker='<!-- claude-review-workflow-skip -->'
+            if ! gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$marker"; then
+              gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          **The automated Claude review cannot run on this PR.** The PR modifies \`.github/workflows/claude-pr-review.yml\`, and \`claude-code-action\` refuses to run from a workflow file that differs from the version on the repository's default branch (anti-tampering). The green "Claude review" check therefore means skipped, not reviewed.
+
+          You can still request a review manually by commenting \`@claude review this PR\` — the \`@claude\` workflow runs from the default branch on comment events, so it always passes the validation.
+
+          $marker
+          EOF
+          )"
+            fi
           fi
       - name: Review pull request with Claude
         if: env.HAS_KEY == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ GPU compatibility is tested without GPU hardware in `test/jlarrays.jl`, using JL
 
 ## Pull Requests
 
-Every PR receives an automated Claude review (`.github/workflows/claude-pr-review.yml`) that posts inline comments and ends with a review verdict: approve, request changes, or comment. When authoring a PR, treat the reviewer's approval as the default bar before merge: address its findings by pushing fixes, or reply in the review threads with reasoning if a finding is mistaken — the reviewer re-runs on every push, and a fresh verdict supersedes the previous one.
+Every PR receives an automated Claude review (`.github/workflows/claude-pr-review.yml`) that posts inline comments and ends with a review verdict: approve, request changes, or comment. PRs that modify that workflow file get no automated review (the action self-skips when its own workflow file differs from the default branch) — a CI-posted comment explains this; comment `@claude review this PR` to request a review manually. When authoring a PR, treat the reviewer's approval as the default bar before merge: address its findings by pushing fixes, or reply in the review threads with reasoning if a finding is mistaken — the reviewer re-runs on every push, and a fresh verdict supersedes the previous one.
 
 Reply in every review thread on your PR before considering the work done: either point at the commit that addresses the finding, or explain why it is mistaken. Do not resolve review threads yourself — the reviewer resolves a thread once convinced (by the fix or by your reply), and replies back when not.
 


### PR DESCRIPTION
## Summary

When a PR modifies `.github/workflows/claude-pr-review.yml`, the automated Claude review self-skips (anti-tampering measure). This PR improves the user experience by posting a detailed PR comment explaining why the review was skipped and how to request a manual review.

## Changes

- **Workflow file (`claude-pr-review.yml`):**
  - Enhanced the "Explain when this PR modifies the review workflow itself" step to post a PR comment when the workflow file is modified
  - The comment explains the anti-tampering mechanism and provides the escape hatch: `@claude review this PR` triggers a manual review via the default-branch workflow
  - Uses a marker comment (`<!-- claude-review-workflow-skip -->`) to avoid posting duplicate explanations on subsequent pushes
  - Updated the notice message to mention the manual review option

- **Documentation (`CLAUDE.md`):**
  - Updated the Pull Requests section to document this behavior for contributors
  - Explains that PRs modifying the workflow file get no automated review and directs users to the CI-posted comment for instructions

## Implementation Details

- The step now requires `GH_TOKEN` and `PR_NUMBER` environment variables to post comments via the GitHub CLI
- Checks for an existing marker comment to prevent duplicate notifications when the PR is updated
- The escape hatch works because `claude.yml` runs from the default branch on comment events, bypassing the anti-tampering check

https://claude.ai/code/session_01DC2hqm4HzNb8RcQ8kENcNv