### PR TITLE
Add weighted data support to StandardizedRBM pcd! trainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Added support for weighted data (`wts` keyword) in `pcd!` for `StandardizedRBM`, matching the plain-`RBM` trainer: weighted visible moments, weighted minibatch gradients with the weighted-minibatch bias correction, and weighted updates of the visible/hidden standardization statistics.
+
 ## 5.7.0
 
 - Fixed `xReLU(layer::nsReLU)`, which built the fixed `γ = 1` array with `ones(size(layer.θ))`, always returning a host `Array{Float64}`. Since this conversion backs `energies`, `cgfs`, `∂cgfs`, `sample_from_inputs` and the other moment functions of `nsReLU`, it promoted the entire hidden-layer computation to `Float64` and, on GPU, forced a host allocation plus a host→device transfer on every call. It now uses `one.(layer.θ)`, preserving both eltype and device ([#119](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/119)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
-- Added support for weighted data (`wts` keyword) in `pcd!` for `StandardizedRBM`, matching the plain-`RBM` trainer: weighted visible moments, weighted minibatch gradients with the weighted-minibatch bias correction, and weighted updates of the visible/hidden standardization statistics.
+- Added support for weighted data (`wts` keyword) in `pcd!` for `StandardizedRBM`, matching the plain-`RBM` trainer: weighted visible moments, weighted minibatch gradients with the weighted-minibatch bias correction, and weighted updates of the visible/hidden standardization statistics. The `callback` now also receives the minibatch weights `wd` (equal to `nothing` when `wts` is not given), consistent with the plain-`RBM` trainer; callbacks that spell out the full keyword list must accept the new keyword (or, more robustly, take a trailing `_...` slurp).
 
 ## 5.7.0
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "5.7.0"
+version = "5.8.0-DEV"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]

--- a/docs/src/training.md
+++ b/docs/src/training.md
@@ -77,11 +77,16 @@ In addition to the standard PCD updates, it:
   - `rescale_hidden`: absorb scale into hidden activation when relevant.
 
 Other common arguments remain the same (`iters`, `batchsize`, `steps`, `optim`,
-`l1_weights`, `l2_weights`, `l2_fields`, `l2l1_weights`, `zerosum`, `callback`, `vm`).
+`wts`, `l1_weights`, `l2_weights`, `l2_fields`, `l2l1_weights`, `zerosum`,
+`callback`, `vm`).
 
 The stdRBM callback is called as:
 
-`callback(; rbm, optim, state, ps, iter, vm, vd, ∂)`.
+`callback(; rbm, optim, state, ps, iter, vm, vd, wd, ∂)`
+
+where `wd` are the weights of the current mini-batch (`nothing` if `wts` was not
+given). Define callbacks with a trailing `_...` slurp (e.g.
+`callback(; rbm, iter, _...) = ...`) to stay robust if more keywords are added.
 
 ## Practical tuning guidelines
 

--- a/repl/stdrbm_mnist_gpu.jl
+++ b/repl/stdrbm_mnist_gpu.jl
@@ -49,7 +49,7 @@ let fig = Makie.Figure()
 end
 
 grad_history = []
-function callback(; rbm, optim, iter, vm, vd, ∂)
+function callback(; rbm, optim, iter, vm, vd, ∂, _...)
     if iszero(iter % 10)
         push!(grad_history, cpu(∂))
     end

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -435,11 +435,12 @@ function pcd!(
     shuffle::Bool = true,
 
     iters::Int = 1, # number of gradient updates
+    wts::Union{AbstractVector, Nothing} = nothing, # data weights
 
     steps::Int = 1,
     vm::AbstractArray = sample_from_inputs(rbm.visible, Falses(size(rbm.visible)..., batchsize)),
 
-    moments = moments_from_samples(rbm.visible, data), # sufficient statistics for visible layer
+    moments = moments_from_samples(rbm.visible, data; wts), # sufficient statistics for visible layer
 
     # regularization
     l2_fields::Real = 0, # visible fields L2 regularization
@@ -469,20 +470,28 @@ function pcd!(
     callback = Returns(nothing)
 )
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
+    @assert isnothing(wts) || size(data)[end] == length(wts)
     @assert 0 ≤ damping ≤ 1
 
-    standardize_visible_from_data!(rbm, data; ϵ = ϵv)
+    standardize_visible_from_data!(rbm, data; wts, ϵ = ϵv)
     zerosum && zerosum!(rbm)
 
-    minibatches = infinite_minibatches(data; batchsize, shuffle)
-    for (iter, (vd,)) in zip(1:iters, minibatches,)
+    # store average weight of each data point
+    wts_mean = isnothing(wts) ? 1 : mean(wts)
+
+    minibatches = infinite_minibatches(data, wts; batchsize, shuffle)
+    for (iter, (vd, wd)) in zip(1:iters, minibatches)
         # update fantasy chains
         vm .= sample_v_from_v(rbm, vm; steps)
 
         # compute gradient
-        ∂d = ∂free_energy(rbm, vd; moments)
+        ∂d = ∂free_energy(rbm, vd; wts = wd, moments)
         ∂m = ∂free_energy(rbm, vm)
         ∂ = ∂d - ∂m
+
+        # correct weighted minibatch bias
+        batch_weight = isnothing(wts) ? 1 : mean(wd) / wts_mean
+        ∂ *= batch_weight
 
         # weight decay
         ∂regularize!(∂, rbm; l2_fields, l1_weights, l2_weights, l2l1_weights, regularize_unstandardized, zerosum)
@@ -492,12 +501,12 @@ function pcd!(
         state, ps = update!(state, ps, gs)
 
         # update standardization
-        standardize_hidden_from_v!(rbm, vd; damping, ϵ=ϵh)
+        standardize_hidden_from_v!(rbm, vd; wts = wd, damping, ϵ=ϵh)
 
         rescale_hidden && rescale_hidden_activations!(rbm)
         zerosum && zerosum!(rbm)
 
-        callback(; rbm, optim, state, ps, iter, vm, vd, ∂)
+        callback(; rbm, optim, state, ps, iter, vm, vd, wd, ∂)
     end
 
     return state, ps

--- a/test/train.jl
+++ b/test/train.jl
@@ -221,6 +221,18 @@ end
     @test gaps.vh < 0.05
 end
 
+@testset "standardized pcd with weighted data" begin
+    seed!(62)
+    data = binary_dataset()
+    wts = [v[1] ? 3.0 : 1.0 for v in eachcol(data)]
+    rbm = standardize(initialize!(BinaryRBM(3, 5), data; wts))
+    pcd!(rbm, data; wts, batchsize = 32, iters = 5000, steps = 5, optim = Adam(1e-3))
+    gaps = moment_gaps(rbm, data; wts)
+    @test gaps.v < 0.05
+    @test gaps.h < 0.05
+    @test gaps.vh < 0.05
+end
+
 @testset "standardized pcd potts moment matching" begin
     seed!(63)
     data = potts_dataset()


### PR DESCRIPTION
## Summary

Extends the `pcd!` trainer for `StandardizedRBM` to support weighted data via a `wts` keyword argument, matching the functionality already available in the plain `RBM` trainer.

## Key Changes

- Added `wts::Union{AbstractVector, Nothing}` parameter to `pcd!` function signature
- Pass weights to `moments_from_samples` for computing weighted visible moments
- Pass weights to `standardize_visible_from_data!` during initialization
- Modified minibatch iteration to unpack both data and weights: `(vd, wd)` from `infinite_minibatches(data, wts; ...)`
- Compute weighted gradients by passing `wts = wd` to `∂free_energy` for data samples
- Implement weighted-minibatch bias correction: scale gradient updates by `mean(wd) / mean(wts)` to account for varying weights across minibatches
- Pass weights to `standardize_hidden_from_v!` for weighted updates of hidden standardization statistics
- Include `wd` in callback parameters for user inspection
- Added assertion to validate weight vector length matches data batch size
- Added comprehensive test case verifying moment matching with weighted data

## Implementation Details

The weighted-minibatch bias correction is crucial: when minibatches have different average weights, the gradient magnitude changes. The correction factor `batch_weight = mean(wd) / mean(wts)` rescales each gradient update to maintain consistent learning dynamics regardless of weight distribution across minibatches.

https://claude.ai/code/session_01XuFHFzJ6QULzjbYAyqFvAW