### PR TITLE
v5.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 5.8.0
 
 - Added support for weighted data (`wts` keyword) in `pcd!` for `StandardizedRBM`, matching the plain-`RBM` trainer: weighted visible moments, weighted minibatch gradients with the weighted-minibatch bias correction, and weighted updates of the visible/hidden standardization statistics. The `callback` now also receives the minibatch weights `wd` (equal to `nothing` when `wts` is not given), consistent with the plain-`RBM` trainer; callbacks that spell out the full keyword list must accept the new keyword (or, more robustly, take a trailing `_...` slurp).
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "5.8.0-DEV"
+version = "5.8.0"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Release commit for v5.8.0: drops the `-DEV` suffix from `version` in Project.toml and renames the `## Unreleased` CHANGELOG section to `## 5.8.0`.

Semver rationale: the only user-facing change since v5.7.0 is a new feature — weighted data (`wts`) support in `pcd!` for `StandardizedRBM`, including the new `wd` callback keyword (#135) — which warrants a minor bump. All other commits since the last release are CI/tooling changes with no package impact.

After this merges, the registration follows the register-new-version skill: frozen `release-5.8.0` branch at the merge commit, then triggering Registrator from issue #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019W2L2sYKXULiuK81AF4rNR

---
_Generated by [Claude Code](https://claude.ai/code/session_019W2L2sYKXULiuK81AF4rNR)_