### PR TITLE
Start 5.8.1-DEV development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
 ## 5.8.0
 
 - Added support for weighted data (`wts` keyword) in `pcd!` for `StandardizedRBM`, matching the plain-`RBM` trainer: weighted visible moments, weighted minibatch gradients with the weighted-minibatch bias correction, and weighted updates of the visible/hidden standardization statistics. The `callback` now also receives the minibatch weights `wd` (equal to `nothing` when `wts` is not given), consistent with the plain-`RBM` trainer; callbacks that spell out the full keyword list must accept the new keyword (or, more robustly, take a trailing `_...` slurp).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "5.8.0"
+version = "5.8.1-DEV"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Now that v5.8.0 is registered in General ([JuliaRegistries/General#161481](https://github.com/JuliaRegistries/General/pull/161481)) and tagged, start the next development cycle per the release workflow: bump Project.toml to `5.8.1-DEV` and add a fresh `## Unreleased` section to CHANGELOG.md, so development commits never accumulate under a released version number.

The `-DEV` number is only a hint — the actual next release number is re-derived from the accumulated changes at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019W2L2sYKXULiuK81AF4rNR

---
_Generated by [Claude Code](https://claude.ai/code/session_019W2L2sYKXULiuK81AF4rNR)_