### PR TITLE
Preserve zero-norm hidden units when rescaling weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Fixed `rescale_weights!` for plain, centered, and standardized RBMs so hidden units with zero-norm incoming weights remain finite and unchanged while every nonzero incoming-weight column is normalized (the equivalent unstandardized column for `StandardizedRBM`). This prevents default `pcd!` from corrupting zero-initialized continuous-hidden models such as `HopfieldRBM` ([#140](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/140)).
+
 ## 5.8.0
 
 - Added support for weighted data (`wts` keyword) in `pcd!` for `StandardizedRBM`, matching the plain-`RBM` trainer: weighted visible moments, weighted minibatch gradients with the weighted-minibatch bias correction, and weighted updates of the visible/hidden standardization statistics. The `callback` now also receives the minibatch weights `wd` (equal to `nothing` when `wts` is not given), consistent with the plain-`RBM` trainer; callbacks that spell out the full keyword list must accept the new keyword (or, more robustly, take a trailing `_...` slurp).

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -351,7 +351,7 @@ function rescale_hidden!(rbm::CenteredRBM, λ::AbstractArray)
 end
 
 function rescale_weights!(rbm::CenteredRBM)
-    λ = inv.(weight_norms(RBM(rbm)))
+    λ = _inv_or_one.(weight_norms(rbm))
     return rescale_hidden!(rbm, λ)
 end
 

--- a/src/gauge/rescale_hidden.jl
+++ b/src/gauge/rescale_hidden.jl
@@ -14,14 +14,17 @@ function rescale_hidden!(rbm::RBM, λ::AbstractArray)
     return false
 end
 
+_inv_or_one(x) = iszero(x) ? one(x) : inv(x)
+
 """
-    rescale_weights!(rbm, λ::AbstractArray)
+    rescale_weights!(rbm)
 
 For continuous hidden units with a scale parameter, scales parameters such that the weights
-attached to each hidden unit have norm 1.
+attached to each hidden unit have norm 1. Hidden units whose incoming weights have zero
+norm are left unchanged.
 """
 function rescale_weights!(rbm::RBM)
-    λ = inv.(weight_norms(rbm))
+    λ = _inv_or_one.(weight_norms(rbm))
     return rescale_hidden!(rbm, λ)
 end
 

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -552,12 +552,13 @@ end
 
 Rescale weights so that the unstandardized weights have norm 1, by re-scaling hidden units.
 This assumes the hidden units have a scale parameter, otherwise it does nothing.
+Hidden units whose incoming unstandardized weights have zero norm are left unchanged.
 Note that the standardized weights are invariant under such rescaling of hidden unit activities,
 and therefore cannot be constrained to have unit norm. So the only sensible choice is to
 rescale the unstandardized weights to have unit norm, as we do here.
 """
 function rescale_weights!(rbm::StandardizedRBM)
-    λ = inv.(weight_norms(rbm))
+    λ = _inv_or_one.(weight_norms(rbm))
     return rescale_hidden!(rbm, λ)
 end
 

--- a/test/centered.jl
+++ b/test/centered.jl
@@ -469,6 +469,31 @@ using RestrictedBoltzmannMachines: RBM, rescale_hidden!, rescale_weights!, weigh
     @test rbm.offset_h == rbm_copy.offset_h
 end
 
+@testset "rescale_weights! of CenteredRBM preserves zero-norm hidden units" begin
+    rbm = CenteredRBM(
+        Binary(; θ = randn(2)),
+        ReLU(; θ = [0.25, -0.5], γ = [1.5, 2.0]),
+        [0.0 3.0; 0.0 4.0],
+        randn(2),
+        [0.75, -0.25],
+    )
+    rbm0 = deepcopy(rbm)
+    v = Bool[0 0 1 1; 0 1 0 1]
+    F0 = free_energy(rbm, v)
+    ω = weight_norms(rbm)
+    @test ω ≈ [0, 5]
+
+    @test @inferred rescale_weights!(rbm)
+    @test weight_norms(rbm) ≈ [0, 1]
+    @test rbm.w[:, 1] == rbm0.w[:, 1]
+    @test rbm.hidden.par[:, 1] == rbm0.hidden.par[:, 1]
+    @test rbm.offset_h[1] == rbm0.offset_h[1]
+    @test all(isfinite, rbm.w)
+    @test all(isfinite, rbm.hidden.par)
+    @test all(isfinite, rbm.offset_h)
+    @test free_energy(rbm, v) ≈ F0 .- log(ω[2])
+end
+
 using LogExpFunctions: softmax
 using RestrictedBoltzmannMachines: Gaussian, pReLU, xReLU, collect_states, var_from_inputs
 

--- a/test/gauge/rescale_hidden.jl
+++ b/test/gauge/rescale_hidden.jl
@@ -4,7 +4,7 @@ using Statistics: mean, var
 using Random: bitrand, rand!, randn!
 using LinearAlgebra: norm
 using RestrictedBoltzmannMachines: RBM, Binary, free_energy, Gaussian, ReLU, dReLU, pReLU, xReLU,
-    sample_v_from_v, sample_h_from_h, mean_from_inputs, var_from_inputs,
+    HopfieldRBM, sample_v_from_v, sample_h_from_h, mean_from_inputs, var_from_inputs,
     rescale_hidden!, rescale_activations!, rescale_weights!,  weight_norms
 
 Random.seed!(23)
@@ -71,6 +71,39 @@ end
     @test ω ≈ [norm(rbm.w)]
     @inferred rescale_weights!(rbm)
     @test free_energy(rbm, v) ≈ F .- sum(log, ω)
+end
+
+@testset "rescale_weights! preserves zero-norm hidden units" begin
+    rbm = RBM(
+        Binary(; θ = randn(2)),
+        Gaussian(; θ = [0.25, -0.5], γ = [1.5, 2.0]),
+        [0.0 3.0; 0.0 4.0],
+    )
+    rbm0 = deepcopy(rbm)
+    v = Bool[0 0 1 1; 0 1 0 1]
+    F0 = free_energy(rbm, v)
+    ω = weight_norms(rbm)
+    @test ω ≈ [0, 5]
+
+    @test @inferred rescale_weights!(rbm)
+    @test weight_norms(rbm) ≈ [0, 1]
+    @test rbm.w[:, 1] == rbm0.w[:, 1]
+    @test rbm.hidden.par[:, 1] == rbm0.hidden.par[:, 1]
+    @test all(isfinite, rbm.w)
+    @test all(isfinite, rbm.hidden.par)
+    @test free_energy(rbm, v) ≈ F0 .- log(ω[2])
+end
+
+@testset "rescale_weights! preserves an all-zero HopfieldRBM" begin
+    rbm = HopfieldRBM(2, 2)
+    rbm0 = deepcopy(rbm)
+
+    @test @inferred rescale_weights!(rbm)
+    @test rbm.w == rbm0.w
+    @test rbm.hidden.par == rbm0.hidden.par
+    @test weight_norms(rbm) == zeros(2)
+    @test all(isfinite, rbm.w)
+    @test all(isfinite, rbm.hidden.par)
 end
 
 using RestrictedBoltzmannMachines: Spin, Potts, PottsGumbel, nsReLU

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -17,7 +17,7 @@ using RestrictedBoltzmannMachines: RBM, CenteredRBM, StandardizedRBM, ∂RBM, Bi
     inputs_h_from_v, inputs_v_from_h, mean_h_from_v, mean_v_from_h,
     sample_h_from_v, sample_v_from_h, sample_v_from_v, reconstruction_error,
     log_pseudolikelihood, log_pseudolikelihood_stoch,
-    initialize!, pcd!, ∂free_energy, zerosum!, rescale_weights!, aise, raise
+    initialize!, pcd!, ∂free_energy, zerosum!, rescale_weights!, weight_norms, aise, raise
 
 JLArrays.allowscalar(false)
 
@@ -193,6 +193,62 @@ end
     rescale_weights!(rbm)
     @test adapt(Array, jl_rbm.w) ≈ rbm.w
     @test adapt(Array, jl_rbm.hidden.par) ≈ rbm.hidden.par
+
+    # Mixed zero/nonzero columns across all model forms. Running these broadcasts with
+    # allowscalar(false) ensures that preserving zero-norm units does not index devices.
+    w = [0.0 3.0; 0.0 4.0]
+    models = (
+        RBM(
+            Binary(; θ = randn(2)),
+            ReLU(; θ = randn(2), γ = 1 .+ rand(2)),
+            copy(w),
+        ),
+        CenteredRBM(
+            Binary(; θ = randn(2)),
+            ReLU(; θ = randn(2), γ = 1 .+ rand(2)),
+            copy(w),
+            randn(2),
+            randn(2),
+        ),
+        StandardizedRBM(
+            Binary(; θ = randn(2)),
+            ReLU(; θ = randn(2), γ = 1 .+ rand(2)),
+            copy(w),
+            randn(2),
+            randn(2),
+            0.5 .+ rand(2),
+            0.5 .+ rand(2),
+        ),
+    )
+    for model0 in models
+        model = deepcopy(model0)
+        jl_model = adapt(JLArray, model0)
+
+        @test rescale_weights!(model)
+        @test rescale_weights!(jl_model)
+
+        actual = adapt(Array, jl_model)
+        @test actual.w ≈ model.w
+        @test actual.hidden.par ≈ model.hidden.par
+        @test weight_norms(actual) ≈ [0, 1]
+        @test actual.w[:, 1] == model0.w[:, 1]
+        @test actual.hidden.par[:, 1] == model0.hidden.par[:, 1]
+        @test all(isfinite, actual.w)
+        @test all(isfinite, actual.hidden.par)
+
+        if actual isa CenteredRBM
+            @test actual.offset_h ≈ model.offset_h
+            @test actual.offset_h[1] == model0.offset_h[1]
+            @test all(isfinite, actual.offset_h)
+        elseif actual isa StandardizedRBM
+            @test actual.offset_h ≈ model.offset_h
+            @test actual.scale_h ≈ model.scale_h
+            @test actual.offset_h[1] == model0.offset_h[1]
+            @test actual.scale_h[1] == model0.scale_h[1]
+            @test all(isfinite, actual.offset_h)
+            @test all(isfinite, actual.scale_h)
+        end
+    end
 
     # zerosum! on StandardizedRBM with nontrivial offsets/scales
     std_rbm = StandardizedRBM(

--- a/test/pcd.jl
+++ b/test/pcd.jl
@@ -1,8 +1,11 @@
+import Random
 using Test: @test, @testset
 using Statistics: mean
 using Random: bitrand
 using Optimisers: Adam
-using RestrictedBoltzmannMachines: RBM, BinaryRBM, sample_v_from_v, initialize!, pcd!
+using RestrictedBoltzmannMachines: RBM, BinaryRBM, HopfieldRBM, sample_v_from_v, initialize!, pcd!
+
+Random.seed!(23)
 
 @testset "pcd" begin
     data = falses(2, 1000)
@@ -18,4 +21,15 @@ using RestrictedBoltzmannMachines: RBM, BinaryRBM, sample_v_from_v, initialize!,
     @test 0.4 < mean(v_sample[1,:]) < 0.6
     @test 0.4 < mean(v_sample[2,:]) < 0.6
     @test 0.4 < mean(v_sample[1,:] .* v_sample[2,:]) < 0.6
+end
+
+@testset "default pcd! with zero-initialized continuous hidden units" begin
+    data = Float64[-1 1 -1 1; -1 -1 1 1]
+    rbm = HopfieldRBM(2, 1)
+
+    pcd!(rbm, data)
+
+    @test all(isfinite, rbm.visible.par)
+    @test all(isfinite, rbm.hidden.par)
+    @test all(isfinite, rbm.w)
 end

--- a/test/standardized.jl
+++ b/test/standardized.jl
@@ -430,6 +430,36 @@ end
     @test free_energy(rbm, v) ≈ free_energy(rbm_copy, v) .- sum(log, weight_norms(rbm_copy))
 end
 
+@testset "rescale_weights! std preserves zero-norm hidden units" begin
+    rbm = StandardizedRBM(
+        Binary(; θ = randn(2)),
+        ReLU(; θ = [0.25, -0.5], γ = [1.5, 2.0]),
+        [0.0 6.0; 0.0 8.0],
+        randn(2),
+        [0.75, -0.25],
+        [2.0, 4.0],
+        [1.5, 2.0],
+    )
+    rbm0 = deepcopy(rbm)
+    v = Bool[0 0 1 1; 0 1 0 1]
+    F0 = free_energy(rbm, v)
+    ω = weight_norms(rbm)
+    @test ω[1] == 0
+    @test ω[2] > 0
+
+    @test @inferred rescale_weights!(rbm)
+    @test weight_norms(rbm) ≈ [0, 1]
+    @test rbm.w == rbm0.w
+    @test rbm.hidden.par[:, 1] == rbm0.hidden.par[:, 1]
+    @test rbm.offset_h[1] == rbm0.offset_h[1]
+    @test rbm.scale_h[1] == rbm0.scale_h[1]
+    @test all(isfinite, rbm.w)
+    @test all(isfinite, rbm.hidden.par)
+    @test all(isfinite, rbm.offset_h)
+    @test all(isfinite, rbm.scale_h)
+    @test free_energy(rbm, v) ≈ F0 .- log(ω[2])
+end
+
 @testset "rescale_weights! std Binary" begin
     rbm = BinaryStandardizedRBM(
         randn(3), randn(2), randn(3,2),


### PR DESCRIPTION
Fixes #140.

## Summary

- use an identity rescaling factor for hidden units whose incoming-weight norm is zero
- keep normalizing every nonzero incoming-weight column, including the equivalent unstandardized columns of `StandardizedRBM`
- apply the same semantics to `RBM`, `CenteredRBM`, and `StandardizedRBM` while preserving the existing gauge transformations and model equivalence
- cover mixed zero/nonzero columns, all-zero `HopfieldRBM`s, default PCD, wrapper state, and JLArray execution with scalar indexing disabled

## Root cause

`rescale_weights!` computed `inv.(weight_norms(rbm))` directly. A zero norm therefore produced an infinite scale, and the subsequent rescaling evaluated products such as `0 * Inf`, corrupting zero weights and continuous-hidden parameters with `NaN`/`Inf`. Default plain PCD invokes this rescaling before its first update, so a zero-initialized `HopfieldRBM` failed immediately.

The shared rescaling-factor rule now maps an exact zero norm to `one(norm)` and every nonzero norm to `inv(norm)`. Broadcasting that scalar rule keeps the implementation generic across array backends and avoids scalar indexing.

## Validation

- `julia --project=test test/gauge/rescale_hidden.jl`
- `julia --project=test test/centered.jl`
- `julia --project=test test/standardized.jl`
- `julia --project=test test/pcd.jl`
- `julia --project=test test/jlarrays.jl`
- `julia --project=. -e 'using Pkg; Pkg.test()'`

All passed locally.
