### PR TITLE
Fix zero-variance visible scaling in standardized PCD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Fixed `pcd!(::StandardizedRBM)` producing non-finite parameters and energies when visible data has zero-variance coordinates, such as constant Binary features or absent Potts categories. Such centered coordinates now use a neutral unit scale; nonconstant coordinates and explicit positive `ϵv` behavior are unchanged ([#139](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/139)).
+
 ## 5.8.0
 
 - Added support for weighted data (`wts` keyword) in `pcd!` for `StandardizedRBM`, matching the plain-`RBM` trainer: weighted visible moments, weighted minibatch gradients with the weighted-minibatch bias correction, and weighted updates of the visible/hidden standardization statistics. The `callback` now also receives the minibatch weights `wd` (equal to `nothing` when `wts` is not given), consistent with the plain-`RBM` trainer; callbacks that spell out the full keyword list must accept the new keyword (or, more robustly, take a trailing `_...` slurp).

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -394,7 +394,11 @@ end
 function standardize_visible_from_data!(rbm::StandardizedRBM, data::AbstractArray; wts = nothing, ϵ::Real = 0)
     μ = batchmean(rbm.visible, data; wts)
     ν = batchvar(rbm.visible, data; wts, mean=μ)
-    return standardize_visible!(rbm, μ, sqrt.(ν .+ ϵ))
+    scale = sqrt.(ν .+ ϵ)
+    # Centered constant coordinates are identically zero, so their scale is arbitrary.
+    # Use the neutral unit scale to avoid dividing by zero during standardization.
+    @. scale = ifelse(iszero(scale), one(scale), scale)
+    return standardize_visible!(rbm, μ, scale)
 end
 
 function standardize_hidden_from_inputs!(rbm::StandardizedRBM, inputs::AbstractArray; wts = nothing, damping::Real = 0, ϵ::Real = 0)

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -250,6 +250,28 @@ end
     @test all(isfinite, adapt(Array, jl_rbm.w))
     @test all(isfinite, adapt(Array, jl_rbm.visible.par))
     @test all(isfinite, adapt(Array, jl_rbm.hidden.par))
+
+    standardized_data = Float32.(bitrand(N..., 32))
+    standardized_data[1, 1, :] .= 0
+    standardized_rbm = StandardizedRBM(
+        BinaryRBM(
+            zeros(Float32, N...), zeros(Float32, 2), fill(0.1f0, N..., 2)
+        )
+    )
+    jl_standardized_data = JLArray(standardized_data)
+    jl_standardized_rbm = adapt(JLArray, standardized_rbm)
+    pcd!(
+        jl_standardized_rbm, jl_standardized_data;
+        iters = 1, batchsize = 16, steps = 1, shuffle = false,
+    )
+    scale_v = adapt(Array, jl_standardized_rbm.scale_v)
+    @test jl_standardized_rbm.scale_v isa JLArray
+    @test scale_v[1, 1] == 1f0
+    @test all(scale_v .> 0)
+    @test all(isfinite, adapt(Array, jl_standardized_rbm.visible.par))
+    @test all(isfinite, adapt(Array, jl_standardized_rbm.hidden.par))
+    @test all(isfinite, adapt(Array, jl_standardized_rbm.w))
+    @test all(isfinite, adapt(Array, free_energy(jl_standardized_rbm, jl_standardized_data)))
 end
 
 @testset "AIS" begin

--- a/test/standardized.jl
+++ b/test/standardized.jl
@@ -257,6 +257,91 @@ end
     @test iszero(rbm.hidden.θ)
 end
 
+@testset "standardized pcd with zero-variance visible features" begin
+    binary_data = Bool[
+        0 0 0 0
+        0 1 0 1
+    ]
+    potts_data = reshape(Bool[
+        1 0 1 0
+        0 1 0 1
+        0 0 0 0
+    ], 3, 1, 4)
+    weighted_binary_data = Bool[
+        0 0 1 1
+        0 1 0 1
+    ]
+    weighted_potts_data = reshape(Bool[
+        1 0 0 0
+        0 1 0 0
+        0 0 1 1
+    ], 3, 1, 4)
+
+    for (
+        data_binary, data_potts, wts,
+        binary_offset, binary_scale, potts_offset, potts_scale,
+    ) in (
+        (
+            binary_data,
+            potts_data,
+            nothing,
+            [0.0, 0.5],
+            [1.0, 0.5],
+            reshape([0.5, 0.5, 0.0], 3, 1),
+            reshape([0.5, 0.5, 1.0], 3, 1),
+        ),
+        (
+            weighted_binary_data,
+            weighted_potts_data,
+            [1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.5],
+            [1.0, 0.5],
+            reshape([0.5, 0.5, 0.0], 3, 1),
+            reshape([0.5, 0.5, 1.0], 3, 1),
+        ),
+    )
+        binary_rbm = standardize(BinaryRBM(zeros(2), zeros(1), fill(0.1, 2, 1)))
+        pcd!(
+            binary_rbm, data_binary;
+            wts, iters = 1, batchsize = 4, steps = 1, shuffle = false,
+        )
+        @test binary_rbm.offset_v ≈ binary_offset
+        @test binary_rbm.scale_v ≈ binary_scale
+
+        potts_rbm = standardize(
+            RBM(Potts((3, 1)), Binary((1,)), fill(0.1, 3, 1, 1))
+        )
+        pcd!(
+            potts_rbm, data_potts;
+            wts, iters = 1, batchsize = 4, steps = 1, shuffle = false,
+        )
+        @test potts_rbm.offset_v ≈ potts_offset
+        @test potts_rbm.scale_v ≈ potts_scale
+
+        for (rbm, data) in ((binary_rbm, data_binary), (potts_rbm, data_potts))
+            @test all(rbm.scale_v .> 0)
+            for par in (
+                rbm.visible.par, rbm.hidden.par, rbm.w,
+                rbm.offset_v, rbm.offset_h, rbm.scale_v, rbm.scale_h,
+            )
+                @test all(isfinite, par)
+            end
+            @test all(isfinite, free_energy(rbm, data))
+        end
+    end
+
+    rbm = standardize(BinaryRBM(zeros(2), zeros(1), fill(0.1, 2, 1)))
+    pcd!(
+        rbm, binary_data;
+        ϵv = 0.04, iters = 1, batchsize = 4, steps = 1, shuffle = false,
+    )
+    @test rbm.scale_v ≈ [0.2, √0.29]
+    @test all(isfinite, rbm.visible.par)
+    @test all(isfinite, rbm.hidden.par)
+    @test all(isfinite, rbm.w)
+    @test all(isfinite, free_energy(rbm, binary_data))
+end
+
 @testset "exact enumeration of configurations" begin
     rbm = BinaryStandardizedRBM(
         randn(2), randn(2), randn(2,2),


### PR DESCRIPTION
## Summary

- replace exactly zero visible scales with a neutral unit scale when standardizing a `StandardizedRBM` from data
- preserve variance-based scaling for nonconstant coordinates and the existing behavior for explicit positive `ϵv`
- add one-step PCD regressions for constant Binary features and absent Potts categories, including coordinates made constant or absent by zero data weights
- verify the fallback stays Float32/backend-generic with JLArrays and scalar indexing disabled
- document the user-facing fix in the changelog

## Root cause

`standardize_visible_from_data!` used `sqrt.(variance .+ ϵv)` directly. With the default `ϵv = 0`, a zero-variance coordinate received `scale_v = 0`. Later standardization and unstandardization divided by that scale, propagating `NaN`/`Inf` through parameters and energies.

For a constant coordinate centered at its mean, every standardized value is zero regardless of the finite scale. A unit scale is therefore a neutral nonsingular choice.

## Validation

- `julia --project=test test/standardized.jl`
- `julia --project=test test/jlarrays.jl`
- `julia --project=. -e 'using Pkg; Pkg.test()'`
- `git diff --check`

Fixes #139
