### PR TITLE
Return +Inf from Gaussian-Gaussian log_partition for non-normalizable RBMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Fixed `log_partition` for Gaussian-Gaussian RBMs, which could return a plausible finite value for a non-normalizable model when the indefinite joint precision had a positive determinant. It now validates the `abs(γ)` joint precision with a checked Cholesky factorization and returns `+Inf` for singular or indefinite models ([#142](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/142)).
+
 ## 5.8.0
 
 - Added support for weighted data (`wts` keyword) in `pcd!` for `StandardizedRBM`, matching the plain-`RBM` trainer: weighted visible moments, weighted minibatch gradients with the weighted-minibatch bias correction, and weighted updates of the visible/hidden standardization statistics. The `callback` now also receives the minibatch weights `wd` (equal to `nothing` when `wts` is not given), consistent with the plain-`RBM` trainer; callbacks that spell out the full keyword list must accept the new keyword (or, more robustly, take a trailing `_...` slurp).

--- a/src/partition.jl
+++ b/src/partition.jl
@@ -5,6 +5,11 @@ Log-partition of `rbm`, computed by extensive enumeration of visible states
 (except for particular cases such as Gaussian-Gaussian RBM).
 This is exponentially slow for large machines.
 
+For Gaussian-Gaussian RBMs, the exact Gaussian integral is used when the joint
+precision matrix (with Gaussian precisions `abs.(γ)`) is positive definite.
+Non-normalizable models with a singular or indefinite joint precision return
+`Inf`.
+
 If your RBM has a smaller hidden layer, mirroring the layers of the `rbm` first
 (see [`mirror`](@ref)).
 """

--- a/src/rbms/gaussian.jl
+++ b/src/rbms/gaussian.jl
@@ -25,15 +25,16 @@ function log_partition(rbm::RBM{<:Gaussian, <:Gaussian})
     γh = vec(abs.(rbm.hidden.γ))
     w = flat_w(rbm)
 
-    lA = block_matrix_logdet(
-        Diagonal(γv), -w,
-        -w', Diagonal(γh)
-    )
+    A = LinearAlgebra.Symmetric([
+        Diagonal(γv) -w
+        -w' Diagonal(γh)
+    ])
+    F = LinearAlgebra.cholesky(A; check = false)
+    logZ0 = length(θ) / 2 * log(2π)
 
-    iA = block_matrix_invert(
-        Diagonal(γv), -w,
-        -w', Diagonal(γh)
-    )
+    if !LinearAlgebra.issuccess(F)
+        return oftype(logZ0 + zero(eltype(F)) + zero(eltype(θ)), Inf)
+    end
 
-    return length(θ)/2 * log(2π) + dot(θ, iA, θ)/2 - lA/2
+    return logZ0 + dot(θ, F \ θ) / 2 - logdet(F) / 2
 end

--- a/test/rbm.jl
+++ b/test/rbm.jl
@@ -363,6 +363,71 @@ end
     @test ∂w ≈ C[1:N, (N + 1):end] # <vi*hμ>
 end
 
+@testset "Gaussian-Gaussian RBM normalizability" begin
+    for T in (Float32, Float64)
+        I2 = diagm(ones(T, 2))
+        θv = T[0.25, -0.5]
+        θh = T[-0.75, 0.125]
+        w = T(0.5) * I2
+
+        rbm = GaussianRBM(θv, T[-1, 1], θh, T[1, -1], w)
+        rbm_positive_γ = GaussianRBM(θv, ones(T, 2), θh, ones(T, 2), w)
+        θ = [θv; θh]
+        A = [I2 -w; -w' I2]
+        expected = length(θ) / 2 * log(2π) + dot(θ, A \ θ) / 2 - logdet(A) / 2
+        logZ = log_partition(rbm)
+
+        @test logZ ≈ expected
+        @test logZ ≈ log_partition(rbm_positive_γ)
+
+        if T === Float64
+            gs = only(gradient(log_partition, rbm))
+            gs_positive_γ = only(gradient(log_partition, rbm_positive_γ))
+            @test gs.visible.par[1, ..] ≈ gs_positive_γ.visible.par[1, ..]
+            @test gs.hidden.par[1, ..] ≈ gs_positive_γ.hidden.par[1, ..]
+            @test gs.visible.par[2, ..] ≈
+                sign.(rbm.visible.γ) .* gs_positive_γ.visible.par[2, ..]
+            @test gs.hidden.par[2, ..] ≈
+                sign.(rbm.hidden.γ) .* gs_positive_γ.hidden.par[2, ..]
+            @test gs.w ≈ gs_positive_γ.w
+        end
+
+        α = one(T) - sqrt(eps(T))
+        δ = one(T) - α
+        θ_boundary = fill(sqrt(δ), 1)
+        rbm_boundary = GaussianRBM(
+            θ_boundary, ones(T, 1),
+            θ_boundary, ones(T, 1),
+            reshape(T[α], 1, 1)
+        )
+        logZ_boundary = log_partition(rbm_boundary)
+        expected_boundary = (
+            log(T(2) * T(π)) + one(T) - (log(δ) + log1p(α)) / T(2)
+        )
+        @test isfinite(logZ_boundary)
+        @test logZ_boundary ≈ expected_boundary rtol = sqrt(eps(T))
+
+        w_indefinite = 2I2
+        A_indefinite = [I2 -w_indefinite; -w_indefinite' I2]
+        @test !isposdef(A_indefinite)
+        @test logdet(A_indefinite) ≈ log(T(9))
+
+        rbm_indefinite = GaussianRBM(
+            zeros(T, 2), ones(T, 2), zeros(T, 2), ones(T, 2), w_indefinite
+        )
+        logZ_indefinite = log_partition(rbm_indefinite)
+        @test isinf(logZ_indefinite) && logZ_indefinite > 0
+        @test typeof(logZ_indefinite) === typeof(logZ)
+
+        rbm_singular = GaussianRBM(
+            zeros(T, 2), ones(T, 2), zeros(T, 2), ones(T, 2), I2
+        )
+        logZ_singular = log_partition(rbm_singular)
+        @test isinf(logZ_singular) && logZ_singular > 0
+        @test typeof(logZ_singular) === typeof(logZ)
+    end
+end
+
 @testset "zero hidden units" begin
     rbm = BinaryRBM(randn(5), randn(0), randn(5,0))
     v = bitrand(5)


### PR DESCRIPTION
Fixes #142.

## Summary

- validate the symmetric Gaussian-Gaussian joint precision using the model's `abs(γ)` semantics
- return `+Inf` when the precision is singular or indefinite
- reuse a checked Cholesky factor for the positive-definite solve and log-determinant
- document the behavior and add Float32/Float64, boundary, and differentiation regressions

## Root cause

The previous implementation applied a block log-determinant and inverse without checking positive definiteness. An indefinite precision with an even number of negative eigenvalues can have a positive determinant, so `log_partition` could return a plausible finite value even though the energy is unbounded below and the partition function diverges.

## Validation

- `julia --project=test test/rbm.jl`
- `julia --project=. -e 'using Pkg; Pkg.test()'`

All listed checks passed locally.
