### PR TITLE
Ignore zero-weight samples during training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file. The format 
   updates, and callbacks. Skipped observations no longer consume the requested
   `iters`, which continues to count parameter updates. Training weights must be
   finite, real, and nonnegative, with at least one positive weight; invalid or
-  globally all-zero weights now fail before the model is mutated
+  globally all-zero weights now fail before the model is mutated, while valid
+  extreme weights are scale-normalized internally to avoid aggregate overflow
   ([#143](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/143)).
 - Fixed `log_partition` for Gaussian-Gaussian RBMs, which could return a plausible finite value for a non-normalizable model when the indefinite joint precision had a positive determinant. It now validates the `abs(γ)` joint precision with a checked Cholesky factorization and returns `+Inf` for singular or indefinite models ([#142](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/142)).
 - Fixed `rescale_weights!` for plain, centered, and standardized RBMs so hidden units with zero-norm incoming weights remain finite and unchanged while every nonzero incoming-weight column is normalized (the equivalent unstandardized column for `StandardizedRBM`). This prevents default `pcd!` from corrupting zero-initialized continuous-hidden models such as `HopfieldRBM` ([#140](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/140)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Fixed weighted training in plain, centered, and standardized `pcd!`, and in
+  `ucd!`, so that zero-weight observations are ignored before data moments,
+  mini-batches, fantasy/coupled-chain work, wrapper statistics, optimizer
+  updates, and callbacks. Skipped observations no longer consume the requested
+  `iters`, which continues to count parameter updates. Training weights must be
+  finite, real, and nonnegative, with at least one positive weight; invalid or
+  globally all-zero weights now fail before the model is mutated
+  ([#143](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/143)).
+
 ## 5.8.0
 
 - Added support for weighted data (`wts` keyword) in `pcd!` for `StandardizedRBM`, matching the plain-`RBM` trainer: weighted visible moments, weighted minibatch gradients with the weighted-minibatch bias correction, and weighted updates of the visible/hidden standardization statistics. The `callback` now also receives the minibatch weights `wd` (equal to `nothing` when `wts` is not given), consistent with the plain-`RBM` trainer; callbacks that spell out the full keyword list must accept the new keyword (or, more robustly, take a trailing `_...` slurp).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -99,14 +99,18 @@ Typical RBM training flow:
 3. train with [`pcd!`](@ref), and
 4. monitor progress with [`log_pseudolikelihood`](@ref) or [`reconstruction_error`](@ref).
 
-Useful [`pcd!`](@ref) arguments:
-- `iters`: number of parameter updates.
+Useful training arguments (shared by [`pcd!`](@ref) and [`ucd!`](@ref) where
+applicable):
+- `iters`: number of completed parameter updates.
 - `batchsize`: mini-batch size.
 - `steps`: Gibbs steps for fantasy-particle updates each iteration.
 - `optim`: optimizer rule from Optimisers.jl.
 - `callback`: receives per-iteration state and can be used for logging.
 - `l1_weights`, `l2_weights`, `l2_fields`, `l2l1_weights`: regularization knobs.
-- `wts`: optional per-sample weights for weighted datasets; supported by the plain `RBM` / centered `pcd!` methods, not by `pcd!(::StandardizedRBM, ...)`.
+- `wts`: optional finite, real, nonnegative per-sample weights, supported by
+  plain, centered, and standardized `pcd!` as well as `ucd!`; zero-weight
+  observations are excluded before training work, and at least one weight must
+  be positive.
 
 ## Documentation guide
 

--- a/docs/src/training.md
+++ b/docs/src/training.md
@@ -34,6 +34,10 @@ the optimizer or callback, or contribute to centered/standardized wrapper
 statistics. This is equivalent to removing those observations and their
 weights before training.
 
+Training calculations rescale positive weights internally without changing
+their relative values, avoiding overflow for finite extreme weights. Callbacks
+still receive the original positive mini-batch weights in `wd`.
+
 The `iters` argument always counts completed parameter updates. Ignored
 zero-weight observations do not consume iterations, and callbacks receive
 consecutive `iter` values from `1` through `iters`.

--- a/docs/src/training.md
+++ b/docs/src/training.md
@@ -7,19 +7,36 @@ CurrentModule = RestrictedBoltzmannMachines
 This page describes how model training works in this package, focusing on:
 
 - [`pcd!`](@ref) for plain `RBM`,
-- specialized [`pcd!`](@ref) for `StandardizedRBM` (stdRBM).
+- specialized [`pcd!`](@ref) for `CenteredRBM` and `StandardizedRBM` (stdRBM),
+- [`ucd!`](@ref) for binary-binary RBMs.
 
 See also the [MNIST example](@ref MNIST) for an end-to-end runnable script.
 
 ## Training workflow
 
-For both plain and standardized RBMs, the usual workflow is:
+The usual training workflow is:
 
 1. Build an RBM (`BinaryRBM`, `GaussianRBM`, `PottsRBM`, ...).
 2. Prepare data with shape `(size(rbm.visible)..., nsamples)`.
 3. Call [`initialize!`](@ref) (for plain RBMs) or `standardize(...)` if using stdRBM.
-4. Train with [`pcd!`](@ref).
+4. Train with [`pcd!`](@ref), or [`ucd!`](@ref) for a binary-binary RBM.
 5. Monitor training with [`log_pseudolikelihood`](@ref), [`reconstruction_error`](@ref), or a callback.
+
+## Weighted data
+
+Plain, centered, and standardized [`pcd!`](@ref), as well as [`ucd!`](@ref),
+accept optional per-sample weights through `wts`. Weights must be finite, real,
+and nonnegative, and at least one weight must be positive.
+
+Observations with zero weight are excluded before data moments and mini-batches
+are formed. They therefore do not advance persistent or coupled chains, reach
+the optimizer or callback, or contribute to centered/standardized wrapper
+statistics. This is equivalent to removing those observations and their
+weights before training.
+
+The `iters` argument always counts completed parameter updates. Ignored
+zero-weight observations do not consume iterations, and callbacks receive
+consecutive `iter` values from `1` through `iters`.
 
 ## How `pcd!` works (plain `RBM`)
 
@@ -35,7 +52,7 @@ At each training iteration, [`pcd!`](@ref) on `RBM`:
 ### Important arguments for `pcd!(rbm::RBM, data; ...)`
 
 - Optimization:
-  - `iters`: number of gradient updates,
+  - `iters`: number of completed parameter updates,
   - `batchsize`: mini-batch size,
   - `optim`: optimizer rule (default `Adam()`),
   - `state`, `ps`: optimizer internals/state containers.
@@ -44,7 +61,7 @@ At each training iteration, [`pcd!`](@ref) on `RBM`:
   - `vm`: initial fantasy particles.
 - Data handling:
   - `shuffle`: reshuffle data between epochs,
-  - `wts`: optional sample weights,
+  - `wts`: optional finite, real, nonnegative sample weights,
   - `moments`: data sufficient statistics (defaults to layer moments from `data`).
 - Regularization:
   - `l2_fields`, `l1_weights`, `l2_weights`, `l2l1_weights`.
@@ -85,7 +102,8 @@ The stdRBM callback is called as:
 `callback(; rbm, optim, state, ps, iter, vm, vd, wd, ∂)`
 
 where `wd` are the weights of the current mini-batch (`nothing` if `wts` was not
-given). Define callbacks with a trailing `_...` slurp (e.g.
+given); zero weights do not appear in these mini-batches. Define callbacks with
+a trailing `_...` slurp (e.g.
 `callback(; rbm, iter, _...) = ...`) to stay robust if more keywords are added.
 
 ## Practical tuning guidelines

--- a/src/RestrictedBoltzmannMachines.jl
+++ b/src/RestrictedBoltzmannMachines.jl
@@ -42,12 +42,12 @@ include("pseudolikelihood.jl")
 include("partition.jl")
 include("ais.jl")
 
+include("train/infinite_minibatches.jl")
 include("train/initialization.jl")
 include("train/pcd.jl")
 include("train/ucd.jl")
 include("train/gradient.jl")
 include("from_grad.jl")
-include("train/infinite_minibatches.jl")
 
 include("gauge/zerosum.jl")
 include("gauge/rescale_hidden.jl")

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -473,16 +473,17 @@ function pcd!(
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     isnothing(wts) || @assert size(data)[end] == length(wts)
 
-    data, wts, batchsize = _prepare_training_data(data, wts; batchsize)
+    data, wts, training_wts, normalization, batchsize =
+        _prepare_training_data(data, wts; batchsize)
     moments === _DEFAULT_MOMENTS &&
-        (moments = moments_from_samples(rbm.visible, data; wts))
+        (moments = moments_from_samples(rbm.visible, data; wts = training_wts))
     vm === _DEFAULT_FANTASY &&
         (vm = sample_from_inputs(
             rbm.visible, Falses(size(rbm.visible)..., batchsize)
         ))
 
     # initial centering from data
-    center_from_data!(rbm, data; wts)
+    center_from_data!(rbm, data; wts = training_wts)
 
     # gauge constraints
     zerosum && zerosum!(rbm)
@@ -492,18 +493,17 @@ function pcd!(
     ps = (; visible = rbm.visible.par, hidden = rbm.hidden.par, w = rbm.w)
     state = setup(optim, ps)
 
-    wts_mean = isnothing(wts) ? 1 : mean(wts)
-
     for (iter, (vd, wd)) in zip(1:iters, infinite_minibatches(data, wts; batchsize))
+        training_wd, batch_weight = _prepare_training_batch(wd, normalization)
+
         # update fantasy chains
         vm .= sample_v_from_v(rbm, vm; steps)
 
         # compute gradient
-        ∂d = ∂free_energy(rbm, vd; wts = wd, moments)
+        ∂d = ∂free_energy(rbm, vd; wts = training_wd, moments)
         ∂m = ∂free_energy(rbm, vm)
         ∂ = ∂d - ∂m
 
-        batch_weight = isnothing(wts) ? 1 : mean(wd) / wts_mean
         ∂ *= batch_weight
 
         # weight decay

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -451,9 +451,9 @@ function pcd!(
     wts::Union{AbstractVector, Nothing} = nothing,
 
     # init fantasy chains
-    vm = sample_from_inputs(rbm.visible, Falses(size(rbm.visible)..., batchsize)),
+    vm = _DEFAULT_FANTASY,
 
-    moments = moments_from_samples(rbm.visible, data; wts),
+    moments = _DEFAULT_MOMENTS,
 
     # damping to update hidden statistics
     hidden_offset_damping::Real = 1//100,
@@ -472,6 +472,14 @@ function pcd!(
 )
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     isnothing(wts) || @assert size(data)[end] == length(wts)
+
+    data, wts, batchsize = _prepare_training_data(data, wts; batchsize)
+    moments === _DEFAULT_MOMENTS &&
+        (moments = moments_from_samples(rbm.visible, data; wts))
+    vm === _DEFAULT_FANTASY &&
+        (vm = sample_from_inputs(
+            rbm.visible, Falses(size(rbm.visible)..., batchsize)
+        ))
 
     # initial centering from data
     center_from_data!(rbm, data; wts)

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -438,9 +438,9 @@ function pcd!(
     wts::Union{AbstractVector, Nothing} = nothing, # data weights
 
     steps::Int = 1,
-    vm::AbstractArray = sample_from_inputs(rbm.visible, Falses(size(rbm.visible)..., batchsize)),
+    vm::Union{AbstractArray, _DefaultFantasy} = _DEFAULT_FANTASY,
 
-    moments = moments_from_samples(rbm.visible, data; wts), # sufficient statistics for visible layer
+    moments = _DEFAULT_MOMENTS, # sufficient statistics for visible layer
 
     # regularization
     l2_fields::Real = 0, # visible fields L2 regularization
@@ -458,7 +458,7 @@ function pcd!(
     # optimiser
     optim::AbstractRule = Adam(),
     ps = (; visible = rbm.visible.par, hidden = rbm.hidden.par, w = rbm.w),
-    state = setup(optim, ps),
+    state = _DEFAULT_OPTIMIZER_STATE,
 
     # Absorb the scale_h into the hidden unit activation (for hidden units with scale parameter).
     # Results in hidden units with var(h) ~ 1.
@@ -472,6 +472,15 @@ function pcd!(
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     @assert isnothing(wts) || size(data)[end] == length(wts)
     @assert 0 ≤ damping ≤ 1
+
+    data, wts, batchsize = _prepare_training_data(data, wts; batchsize)
+    moments === _DEFAULT_MOMENTS &&
+        (moments = moments_from_samples(rbm.visible, data; wts))
+    vm === _DEFAULT_FANTASY &&
+        (vm = sample_from_inputs(
+            rbm.visible, Falses(size(rbm.visible)..., batchsize)
+        ))
+    state === _DEFAULT_OPTIMIZER_STATE && (state = setup(optim, ps))
 
     standardize_visible_from_data!(rbm, data; wts, ϵ = ϵv)
     zerosum && zerosum!(rbm)

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -473,33 +473,32 @@ function pcd!(
     @assert isnothing(wts) || size(data)[end] == length(wts)
     @assert 0 ≤ damping ≤ 1
 
-    data, wts, batchsize = _prepare_training_data(data, wts; batchsize)
+    data, wts, training_wts, normalization, batchsize =
+        _prepare_training_data(data, wts; batchsize)
     moments === _DEFAULT_MOMENTS &&
-        (moments = moments_from_samples(rbm.visible, data; wts))
+        (moments = moments_from_samples(rbm.visible, data; wts = training_wts))
     vm === _DEFAULT_FANTASY &&
         (vm = sample_from_inputs(
             rbm.visible, Falses(size(rbm.visible)..., batchsize)
         ))
     state === _DEFAULT_OPTIMIZER_STATE && (state = setup(optim, ps))
 
-    standardize_visible_from_data!(rbm, data; wts, ϵ = ϵv)
+    standardize_visible_from_data!(rbm, data; wts = training_wts, ϵ = ϵv)
     zerosum && zerosum!(rbm)
-
-    # store average weight of each data point
-    wts_mean = isnothing(wts) ? 1 : mean(wts)
 
     minibatches = infinite_minibatches(data, wts; batchsize, shuffle)
     for (iter, (vd, wd)) in zip(1:iters, minibatches)
+        training_wd, batch_weight = _prepare_training_batch(wd, normalization)
+
         # update fantasy chains
         vm .= sample_v_from_v(rbm, vm; steps)
 
         # compute gradient
-        ∂d = ∂free_energy(rbm, vd; wts = wd, moments)
+        ∂d = ∂free_energy(rbm, vd; wts = training_wd, moments)
         ∂m = ∂free_energy(rbm, vm)
         ∂ = ∂d - ∂m
 
         # correct weighted minibatch bias
-        batch_weight = isnothing(wts) ? 1 : mean(wd) / wts_mean
         ∂ *= batch_weight
 
         # weight decay
@@ -510,7 +509,7 @@ function pcd!(
         state, ps = update!(state, ps, gs)
 
         # update standardization
-        standardize_hidden_from_v!(rbm, vd; wts = wd, damping, ϵ=ϵh)
+        standardize_hidden_from_v!(rbm, vd; wts = training_wd, damping, ϵ=ϵh)
 
         rescale_hidden && rescale_hidden_activations!(rbm)
         zerosum && zerosum!(rbm)

--- a/src/train/gradient.jl
+++ b/src/train/gradient.jl
@@ -72,7 +72,7 @@ function ∂interaction_energy(rbm::RBM, v::AbstractArray, h::AbstractArray; wts
             ∂wflat = -vflat * hflat' / size(vflat, 2)
         else
             @assert size(wts) == bsz
-            ∂wflat = -vflat * Diagonal(vec(wts)) * hflat' / sum(wts)
+            ∂wflat = -(vflat .* reshape(wts, 1, :)) * hflat' / sum(wts)
         end
     end
     ∂w = reshape(∂wflat, size(rbm.w))

--- a/src/train/infinite_minibatches.jl
+++ b/src/train/infinite_minibatches.jl
@@ -102,7 +102,7 @@ function _prepare_training_data(
     # moments and gradients so finite weights cannot overflow their sum/mean.
     # Keep the raw weights separately so callbacks continue to receive them.
     scale = maximum(wts)
-    T = promote_type(typeof(scale), Float32)
+    T = promote_type(float(typeof(scale)), Float32)
     training_wts = T.(wts) ./ T(scale)
     normalization = (; scale, mean = mean(training_wts))
 
@@ -121,7 +121,7 @@ function _prepare_training_batch(
     normalization::NamedTuple,
 )
     scale = maximum(wts)
-    T = promote_type(typeof(scale), Float32)
+    T = promote_type(float(typeof(scale)), Float32)
     training_wts = T.(wts) ./ T(scale)
     batch_weight = (scale / normalization.scale) *
         (mean(training_wts) / normalization.mean)

--- a/src/train/infinite_minibatches.jl
+++ b/src/train/infinite_minibatches.jl
@@ -79,7 +79,7 @@ function _prepare_training_data(
     batchsize::Int,
 )
     batchsize > 0 || throw(ArgumentError("batchsize must be positive"))
-    isnothing(wts) && return data, wts, batchsize
+    isnothing(wts) && return data, wts, wts, nothing, batchsize
 
     length(wts) == size(data, ndims(data)) ||
         throw(DimensionMismatch("length(wts) must equal the number of data samples"))
@@ -98,9 +98,32 @@ function _prepare_training_data(
         data, wts = getobs(positive_indices, data, wts)
     end
 
-    wts_mean = mean(wts)
-    isfinite(wts_mean) && wts_mean > 0 ||
-        throw(ArgumentError("the mean of the positive sample weights must be finite"))
+    # Weighted training is invariant to a common scale factor. Normalize before
+    # moments and gradients so finite weights cannot overflow their sum/mean.
+    # Keep the raw weights separately so callbacks continue to receive them.
+    scale = maximum(wts)
+    T = promote_type(typeof(scale), Float32)
+    training_wts = T.(wts) ./ T(scale)
+    normalization = (; scale, mean = mean(training_wts))
 
-    return data, wts, min(batchsize, npositive)
+    return data, wts, training_wts, normalization, min(batchsize, npositive)
+end
+
+function _prepare_training_batch(
+    wts::Nothing,
+    normalization::Nothing,
+)
+    return wts, 1
+end
+
+function _prepare_training_batch(
+    wts::AbstractVector,
+    normalization::NamedTuple,
+)
+    scale = maximum(wts)
+    T = promote_type(typeof(scale), Float32)
+    training_wts = T.(wts) ./ T(scale)
+    batch_weight = (scale / normalization.scale) *
+        (mean(training_wts) / normalization.mean)
+    return training_wts, batch_weight
 end

--- a/src/train/infinite_minibatches.jl
+++ b/src/train/infinite_minibatches.jl
@@ -1,3 +1,15 @@
+struct _DefaultMoments end
+const _DEFAULT_MOMENTS = _DefaultMoments()
+
+struct _DefaultFantasy end
+const _DEFAULT_FANTASY = _DefaultFantasy()
+
+struct _DefaultOptimizerState end
+const _DEFAULT_OPTIMIZER_STATE = _DefaultOptimizerState()
+
+struct _DefaultChainCount end
+const _DEFAULT_CHAIN_COUNT = _DefaultChainCount()
+
 function nobs(d::AbstractArray, ds::Union{AbstractArray, Nothing}...)
     n = nobs(d)
     ns = nobs(ds...)
@@ -59,4 +71,36 @@ function infinite_minibatches(
 )
     batchsize > 0 || throw(ArgumentError("batchsize must be positive"))
     return InfiniteMinibatchIterator(ds, batchsize, shuffle)
+end
+
+function _prepare_training_data(
+    data::AbstractArray,
+    wts::Union{AbstractVector, Nothing};
+    batchsize::Int,
+)
+    batchsize > 0 || throw(ArgumentError("batchsize must be positive"))
+    isnothing(wts) && return data, wts, batchsize
+
+    length(wts) == size(data, ndims(data)) ||
+        throw(DimensionMismatch("length(wts) must equal the number of data samples"))
+    all(w -> w isa Real && isfinite(w) && w ≥ 0, wts) ||
+        throw(ArgumentError("wts must contain only finite, nonnegative real values"))
+
+    positive = map(w -> !iszero(w), wts)
+    npositive = count(positive)
+    npositive > 0 ||
+        throw(ArgumentError("wts must contain at least one positive weight"))
+
+    if npositive < length(wts)
+        # GPUArrays do not generally support logical indexing. Transfer only
+        # the mask used to build indices; indexing preserves the data backend.
+        positive_indices = findall(adapt(Array, positive))
+        data, wts = getobs(positive_indices, data, wts)
+    end
+
+    wts_mean = mean(wts)
+    isfinite(wts_mean) && wts_mean > 0 ||
+        throw(ArgumentError("the mean of the positive sample weights must be finite"))
+
+    return data, wts, min(batchsize, npositive)
 end

--- a/src/train/infinite_minibatches.jl
+++ b/src/train/infinite_minibatches.jl
@@ -73,6 +73,13 @@ function infinite_minibatches(
     return InfiniteMinibatchIterator(ds, batchsize, shuffle)
 end
 
+function _training_weight_accumulator_type(::Type{T}) where {T}
+    F = float(T)
+    # One wider IEEE type can represent the ratio between any two finite,
+    # positive Float16 or Float32 values without underflow.
+    return F === Float16 ? Float32 : F === Float32 ? Float64 : F
+end
+
 function _prepare_training_data(
     data::AbstractArray,
     wts::Union{AbstractVector, Nothing};
@@ -102,7 +109,7 @@ function _prepare_training_data(
     # moments and gradients so finite weights cannot overflow their sum/mean.
     # Keep the raw weights separately so callbacks continue to receive them.
     scale = maximum(wts)
-    T = promote_type(float(typeof(scale)), Float32)
+    T = _training_weight_accumulator_type(typeof(scale))
     training_wts = T.(wts) ./ T(scale)
     normalization = (; scale, mean = mean(training_wts))
 
@@ -121,9 +128,12 @@ function _prepare_training_batch(
     normalization::NamedTuple,
 )
     scale = maximum(wts)
-    T = promote_type(float(typeof(scale)), Float32)
+    T = promote_type(
+        _training_weight_accumulator_type(typeof(scale)),
+        typeof(normalization.mean),
+    )
     training_wts = T.(wts) ./ T(scale)
-    batch_weight = (scale / normalization.scale) *
+    batch_weight = (T(scale) / T(normalization.scale)) *
         (mean(training_wts) / normalization.mean)
     return training_wts, batch_weight
 end

--- a/src/train/pcd.jl
+++ b/src/train/pcd.jl
@@ -70,9 +70,10 @@ function pcd!(
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     @assert isnothing(wts) || size(data)[end] == length(wts)
 
-    data, wts, batchsize = _prepare_training_data(data, wts; batchsize)
+    data, wts, training_wts, normalization, batchsize =
+        _prepare_training_data(data, wts; batchsize)
     moments === _DEFAULT_MOMENTS &&
-        (moments = moments_from_samples(rbm.visible, data; wts))
+        (moments = moments_from_samples(rbm.visible, data; wts = training_wts))
     vm === _DEFAULT_FANTASY &&
         (vm = sample_from_inputs(
             rbm.visible, Falses(size(rbm.visible)..., batchsize)
@@ -83,20 +84,18 @@ function pcd!(
     zerosum && zerosum!(rbm)
     rescale && rescale_weights!(rbm)
 
-    # store average weight of each data point
-    wts_mean = isnothing(wts) ? 1 : mean(wts)
-
     for (iter, (vd, wd)) in zip(1:iters, infinite_minibatches(data, wts; batchsize, shuffle))
+        training_wd, batch_weight = _prepare_training_batch(wd, normalization)
+
         # update fantasy chains
         vm .= sample_v_from_v(rbm, vm; steps)
 
         # compute gradient
-        ∂d = ∂free_energy(rbm, vd; wts = wd, moments)
+        ∂d = ∂free_energy(rbm, vd; wts = training_wd, moments)
         ∂m = ∂free_energy(rbm, vm)
         ∂ = ∂d - ∂m
 
         # correct weighted minibatch bias
-        batch_weight = isnothing(wts) ? 1 : mean(wd) / wts_mean
         ∂ *= batch_weight
 
         # weight decay

--- a/src/train/pcd.jl
+++ b/src/train/pcd.jl
@@ -13,11 +13,13 @@ parameters with an `Optimisers.jl` rule.
 # Keyword arguments
 - `batchsize::Int=1`: number of samples per update.
 - `iters::Int=1`: number of parameter updates.
-- `wts::Union{AbstractVector,Nothing}=nothing`: optional per-sample weights.
+- `wts::Union{AbstractVector,Nothing}=nothing`: optional finite, nonnegative
+  per-sample weights. Zero-weight samples are ignored, and at least one weight
+  must be positive.
 - `steps::Int=1`: Gibbs steps used to update persistent chains each iteration.
 - `optim::AbstractRule=Adam()`: optimizer rule from `Optimisers.jl`.
 - `moments=moments_from_samples(rbm.visible, data; wts)`: data moments used by
-  the positive phase.
+  the positive phase, computed after zero-weight samples are removed.
 - `l2_fields::Real=0`: L2 regularization on visible fields.
 - `l1_weights::Real=0`: L1 regularization on interaction weights.
 - `l2_weights::Real=0`: L2 regularization on interaction weights.
@@ -42,7 +44,7 @@ function pcd!(
     wts::Union{AbstractVector, Nothing} = nothing, # data weights
     steps::Int = 1, # MC steps to update fantasy chains
     optim::AbstractRule = Adam(), # optimizer rule
-    moments = moments_from_samples(rbm.visible, data; wts), # sufficient statistics for visible layer
+    moments = _DEFAULT_MOMENTS, # sufficient statistics for visible layer
 
     # regularization
     l2_fields::Real = 0, # visible fields L2 regularization
@@ -57,16 +59,25 @@ function pcd!(
     callback = Returns(nothing), # called for every batch
 
     # init fantasy chains
-    vm = sample_from_inputs(rbm.visible, Falses(size(rbm.visible)..., batchsize)),
+    vm = _DEFAULT_FANTASY,
 
     shuffle::Bool = true,
 
     # parameters to optimize
     ps = (; visible = rbm.visible.par, hidden = rbm.hidden.par, w = rbm.w),
-    state = setup(optim, ps) # initialize optimiser state
+    state = _DEFAULT_OPTIMIZER_STATE,
 )
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     @assert isnothing(wts) || size(data)[end] == length(wts)
+
+    data, wts, batchsize = _prepare_training_data(data, wts; batchsize)
+    moments === _DEFAULT_MOMENTS &&
+        (moments = moments_from_samples(rbm.visible, data; wts))
+    vm === _DEFAULT_FANTASY &&
+        (vm = sample_from_inputs(
+            rbm.visible, Falses(size(rbm.visible)..., batchsize)
+        ))
+    state === _DEFAULT_OPTIMIZER_STATE && (state = setup(optim, ps))
 
     # gauge constraints
     zerosum && zerosum!(rbm)

--- a/src/train/ucd.jl
+++ b/src/train/ucd.jl
@@ -197,20 +197,20 @@ function ucd!(
     @assert isnothing(wts) || size(data)[end] == length(wts)
     @assert max_resamples ≥ 0
 
-    data, wts, batchsize = _prepare_training_data(data, wts; batchsize)
+    data, wts, training_wts, normalization, batchsize =
+        _prepare_training_data(data, wts; batchsize)
     nchains === _DEFAULT_CHAIN_COUNT && (nchains = batchsize)
     @assert nchains > 0
     moments === _DEFAULT_MOMENTS &&
-        (moments = moments_from_samples(rbm.visible, data; wts))
+        (moments = moments_from_samples(rbm.visible, data; wts = training_wts))
     state === _DEFAULT_OPTIMIZER_STATE && (state = setup(optim, ps))
 
     zerosum && zerosum!(rbm)
     rescale && rescale_weights!(rbm)
 
-    wts_mean = isnothing(wts) ? 1 : mean(wts)
-
     for (iter, (vd, wd)) in zip(1:iters, infinite_minibatches(data, wts; batchsize, shuffle))
-        ∂d = ∂free_energy(rbm, vd; wts = wd, moments)
+        training_wd, batch_weight = _prepare_training_batch(wd, normalization)
+        ∂d = ∂free_energy(rbm, vd; wts = training_wd, moments)
 
         ∂m = _zero_gradient(rbm)
         meeting_steps = 0
@@ -235,7 +235,6 @@ function ucd!(
 
         ∂ = ∂d - ∂m
 
-        batch_weight = isnothing(wts) ? 1 : mean(wd) / wts_mean
         ∂ *= batch_weight
 
         ∂regularize!(∂, rbm; l2_fields, l1_weights, l2_weights, l2l1_weights, zerosum)

--- a/src/train/ucd.jl
+++ b/src/train/ucd.jl
@@ -157,6 +157,9 @@ end
     ucd!(rbm, data)
 
 Train a binary-binary RBM on data using Unbiased Contrastive Divergence.
+When provided, `wts` must contain finite, nonnegative per-sample weights with
+positive total weight. Zero-weight samples are ignored before minibatches are
+formed, and therefore do not consume any of the `iters` parameter updates.
 The callback receives the current minibatch together with average `meeting_steps`
 and `discarded` trial counts across unbiased chains. For the UCD algorithm and
 binary RBM reference implementation, see Qiu, Zhang, and Wang (2020,
@@ -172,13 +175,13 @@ function ucd!(
     batchsize::Int = 1,
     iters::Int = 1,
     wts::Union{AbstractVector, Nothing} = nothing,
-    nchains::Int = batchsize,
+    nchains::Union{Int, _DefaultChainCount} = _DEFAULT_CHAIN_COUNT,
     min_steps::Int = 1,
     max_steps::Int = 100,
     max_tries::Int = 500,
     max_resamples::Int = 100,
     optim::AbstractRule = Adam(),
-    moments = moments_from_samples(rbm.visible, data; wts),
+    moments = _DEFAULT_MOMENTS,
     l2_fields::Real = 0,
     l1_weights::Real = 0,
     l2_weights::Real = 0,
@@ -188,12 +191,18 @@ function ucd!(
     callback = Returns(nothing),
     shuffle::Bool = true,
     ps = (; visible = rbm.visible.par, hidden = rbm.hidden.par, w = rbm.w),
-    state = setup(optim, ps),
+    state = _DEFAULT_OPTIMIZER_STATE,
 )
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     @assert isnothing(wts) || size(data)[end] == length(wts)
-    @assert nchains > 0
     @assert max_resamples ≥ 0
+
+    data, wts, batchsize = _prepare_training_data(data, wts; batchsize)
+    nchains === _DEFAULT_CHAIN_COUNT && (nchains = batchsize)
+    @assert nchains > 0
+    moments === _DEFAULT_MOMENTS &&
+        (moments = moments_from_samples(rbm.visible, data; wts))
+    state === _DEFAULT_OPTIMIZER_STATE && (state = setup(optim, ps))
 
     zerosum && zerosum!(rbm)
     rescale && rescale_weights!(rbm)

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -250,6 +250,15 @@ end
     @test all(isfinite, adapt(Array, jl_rbm.w))
     @test all(isfinite, adapt(Array, jl_rbm.visible.par))
     @test all(isfinite, adapt(Array, jl_rbm.hidden.par))
+
+    wts = JLArray(vcat(zeros(256), ones(256)))
+    pcd!(
+        jl_rbm, jl_data;
+        wts, iters = 2, batchsize = 32, steps = 0, shuffle = false,
+    )
+    @test all(isfinite, adapt(Array, jl_rbm.w))
+    @test all(isfinite, adapt(Array, jl_rbm.visible.par))
+    @test all(isfinite, adapt(Array, jl_rbm.hidden.par))
 end
 
 @testset "AIS" begin

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -307,7 +307,7 @@ end
     @test all(isfinite, adapt(Array, jl_rbm.visible.par))
     @test all(isfinite, adapt(Array, jl_rbm.hidden.par))
 
-    wts = JLArray(vcat(zeros(256), ones(256)))
+    wts = JLArray(vcat(zeros(256), fill(floatmax(Float64), 256)))
     pcd!(
         jl_rbm, jl_data;
         wts, iters = 2, batchsize = 32, steps = 0, shuffle = false,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ module zerosum_tests include("gauge/zerosum.jl") end
 module rescale_hidden_tests include("gauge/rescale_hidden.jl") end
 module pcd_tests include("pcd.jl") end
 module ucd_tests include("ucd.jl") end
+module zero_weight_training_tests include("zero_weight_training.jl") end
 module train_tests include("train.jl") end
 module shift_fields_tests include("shift_fields.jl") end
 module pottsgumbel_tests include("pottsgumbel.jl") end

--- a/test/zero_weight_training.jl
+++ b/test/zero_weight_training.jl
@@ -1,0 +1,444 @@
+using Test: @test, @testset, @test_throws
+using Random: seed!
+import Optimisers
+import RestrictedBoltzmannMachines as RBMs
+using RestrictedBoltzmannMachines: RBM, Binary, Gaussian, BinaryRBM,
+    CenteredRBM, StandardizedRBM, center, standardize, pcd!, ucd!
+
+struct CountingDescent{T,R} <: Optimisers.AbstractRule
+    eta::T
+    calls::R
+end
+
+Optimisers.init(::CountingDescent, x::AbstractArray) = nothing
+
+function Optimisers.apply!(rule::CountingDescent, state, x, dx)
+    rule.calls[] += 1
+    return state, rule.eta .* dx
+end
+
+struct MutatingInitRule{R} <: Optimisers.AbstractRule
+    calls::R
+end
+
+function Optimisers.init(rule::MutatingInitRule, x::AbstractArray)
+    rule.calls[] += 1
+    x .+= one(eltype(x))
+    return nothing
+end
+
+Optimisers.apply!(::MutatingInitRule, state, x, dx) = (state, dx)
+
+function base_rbm()
+    return BinaryRBM([0.1, -0.2], [0.05], reshape([0.2, -0.1], 2, 1))
+end
+
+wrap_rbm(::Val{:plain}, rbm::RBM) = rbm
+wrap_rbm(::Val{:centered}, rbm::RBM) = center(rbm)
+wrap_rbm(::Val{:standardized}, rbm::RBM) = standardize(rbm)
+
+function model_state(rbm::RBM)
+    return (; visible = copy(rbm.visible.par), hidden = copy(rbm.hidden.par), w = copy(rbm.w))
+end
+
+function model_state(rbm::CenteredRBM)
+    return (;
+        visible = copy(rbm.visible.par),
+        hidden = copy(rbm.hidden.par),
+        w = copy(rbm.w),
+        offset_v = copy(rbm.offset_v),
+        offset_h = copy(rbm.offset_h),
+    )
+end
+
+function model_state(rbm::StandardizedRBM)
+    return (;
+        visible = copy(rbm.visible.par),
+        hidden = copy(rbm.hidden.par),
+        w = copy(rbm.w),
+        offset_v = copy(rbm.offset_v),
+        offset_h = copy(rbm.offset_h),
+        scale_v = copy(rbm.scale_v),
+        scale_h = copy(rbm.scale_h),
+    )
+end
+
+all_finite(rbm) = all(x -> all(isfinite, x), values(model_state(rbm)))
+
+function callback_log()
+    iterations = Int[]
+    weights = Any[]
+    callback = (; iter, wd, kwargs...) -> begin
+        push!(iterations, iter)
+        push!(weights, copy(wd))
+        return nothing
+    end
+    return (; callback, iterations, weights)
+end
+
+function weighted_data()
+    # The NaNs are deliberately attached only to zero-weight observations. If
+    # zero weights are truly ignored, none of the training paths ever sees them.
+    data = [
+        NaN NaN 0.0 1.0
+        NaN NaN 1.0 0.0
+    ]
+    wts = [0.0, 0.0, 1.0, 2.0]
+    return data, wts
+end
+
+function train_pcd!(
+    ::Val{:plain}, rbm, data, wts, vm, optim, callback;
+    iters::Int, batchsize::Int,
+)
+    return pcd!(
+        rbm, data;
+        wts, vm, optim, callback, iters, batchsize,
+        steps = 1, shuffle = false, zerosum = false, rescale = false,
+    )
+end
+
+function train_pcd!(
+    ::Val{:centered}, rbm, data, wts, vm, optim, callback;
+    iters::Int, batchsize::Int,
+)
+    return pcd!(
+        rbm, data;
+        wts, vm, optim, callback, iters, batchsize,
+        steps = 1, hidden_offset_damping = 1//4,
+        zerosum = false, rescale = false,
+    )
+end
+
+function train_pcd!(
+    ::Val{:standardized}, rbm, data, wts, vm, optim, callback;
+    iters::Int, batchsize::Int,
+)
+    return pcd!(
+        rbm, data;
+        wts, vm, optim, callback, iters, batchsize,
+        steps = 1, shuffle = false, damping = 1//4, ϵv = 0.1, ϵh = 0.1,
+        zerosum = false, rescale_hidden = false,
+    )
+end
+
+function check_pcd_filter_equivalence(kind, seed)
+    data, wts = weighted_data()
+    positive = findall(!iszero, wts)
+    filtered_data = data[:, positive]
+    filtered_wts = wts[positive]
+
+    initial = base_rbm()
+    mixed_rbm = wrap_rbm(kind, deepcopy(initial))
+    filtered_rbm = wrap_rbm(kind, deepcopy(initial))
+    mixed_vm = falses(2, 2)
+    filtered_vm = copy(mixed_vm)
+
+    mixed_calls = Ref(0)
+    filtered_calls = Ref(0)
+    mixed_log = callback_log()
+
+    seed!(seed)
+    train_pcd!(
+        kind, mixed_rbm, data, wts, mixed_vm,
+        CountingDescent(0.01, mixed_calls), mixed_log.callback;
+        iters = 2, batchsize = 2,
+    )
+    seed!(seed)
+    train_pcd!(
+        kind, filtered_rbm, filtered_data, filtered_wts, filtered_vm,
+        CountingDescent(0.01, filtered_calls), Returns(nothing);
+        iters = 2, batchsize = 2,
+    )
+
+    @test mixed_log.iterations == 1:2
+    @test length(mixed_log.weights) == 2
+    @test all(wd -> all(w -> w > 0, wd), mixed_log.weights)
+    @test mixed_calls[] == filtered_calls[] == 3 * 2
+    @test model_state(mixed_rbm) == model_state(filtered_rbm)
+    @test mixed_vm == filtered_vm
+    @test all_finite(mixed_rbm)
+    return nothing
+end
+
+@testset "zero-weight PCD matches filtering ($name)" for (name, kind, seed) in [
+    ("plain", Val(:plain), 101),
+    ("centered", Val(:centered), 102),
+    ("standardized", Val(:standardized), 103),
+]
+    check_pcd_filter_equivalence(kind, seed)
+end
+
+@testset "zero-weight UCD matches filtering" begin
+    data, wts = weighted_data()
+    positive = findall(!iszero, wts)
+    filtered_data = data[:, positive]
+    filtered_wts = wts[positive]
+
+    mixed_rbm = base_rbm()
+    filtered_rbm = deepcopy(mixed_rbm)
+    mixed_calls = Ref(0)
+    filtered_calls = Ref(0)
+    mixed_log = callback_log()
+    filtered_log = callback_log()
+    mixed_chain_stats = Tuple{Float64,Float64}[]
+    filtered_chain_stats = Tuple{Float64,Float64}[]
+    mixed_callback = (; meeting_steps, discarded, kwargs...) -> begin
+        mixed_log.callback(; kwargs...)
+        push!(mixed_chain_stats, (meeting_steps, discarded))
+        return nothing
+    end
+    filtered_callback = (; meeting_steps, discarded, kwargs...) -> begin
+        filtered_log.callback(; kwargs...)
+        push!(filtered_chain_stats, (meeting_steps, discarded))
+        return nothing
+    end
+
+    seed!(104)
+    ucd!(
+        mixed_rbm, data;
+        wts, batchsize = 2, iters = 2, nchains = 1,
+        min_steps = 1, max_steps = 64, max_resamples = 100,
+        optim = CountingDescent(0.01, mixed_calls),
+        callback = mixed_callback, shuffle = false, zerosum = false, rescale = false,
+    )
+    seed!(104)
+    ucd!(
+        filtered_rbm, filtered_data;
+        wts = filtered_wts, batchsize = 2, iters = 2, nchains = 1,
+        min_steps = 1, max_steps = 64, max_resamples = 100,
+        optim = CountingDescent(0.01, filtered_calls),
+        callback = filtered_callback, shuffle = false, zerosum = false, rescale = false,
+    )
+
+    @test mixed_log.iterations == filtered_log.iterations == 1:2
+    @test all(wd -> all(w -> w > 0, wd), mixed_log.weights)
+    @test mixed_calls[] == filtered_calls[] == 3 * 2
+    @test mixed_chain_stats == filtered_chain_stats
+    @test model_state(mixed_rbm) == model_state(filtered_rbm)
+    @test all_finite(mixed_rbm)
+end
+
+@testset "invalid training weights" begin
+    data = zeros(2, 2)
+    for bad_wts in (
+        [2.0, -1.0],
+        [1.0, NaN],
+        [1.0, Inf],
+        ComplexF64[1, 1],
+    )
+        @test_throws ArgumentError RBMs._prepare_training_data(data, bad_wts; batchsize = 1)
+        rbm = base_rbm()
+        before = model_state(rbm)
+        @test_throws ArgumentError pcd!(
+            rbm, data;
+            wts = bad_wts, batchsize = 1, iters = 0,
+            zerosum = false, rescale = false,
+        )
+        @test model_state(rbm) == before
+    end
+end
+
+function mutation_sensitive_rbm(::Val{:plain})
+    return RBM(
+        Binary(; θ = [0.1, -0.2]),
+        Gaussian(; θ = [0.3], γ = [2.0]),
+        reshape([3.0, 4.0], 2, 1),
+    )
+end
+
+mutation_sensitive_rbm(kind) = wrap_rbm(kind, base_rbm())
+
+function check_all_zero_pcd(kind)
+    data = [0.0 1.0; 1.0 0.0]
+    wts = zeros(2)
+    rbm = mutation_sensitive_rbm(kind)
+    before = model_state(rbm)
+    init_calls = Ref(0)
+    callbacks = Ref(0)
+
+    seed!(106)
+    expected_next_random = rand()
+    seed!(106)
+    @test_throws ArgumentError pcd!(
+        rbm, data;
+        wts, batchsize = 2, iters = 1, steps = 1,
+        optim = MutatingInitRule(init_calls),
+        callback = (; kwargs...) -> (callbacks[] += 1),
+    )
+    @test model_state(rbm) == before
+    @test rand() == expected_next_random
+    @test iszero(init_calls[])
+    @test iszero(callbacks[])
+    return nothing
+end
+
+@testset "all-zero weights fail before mutation ($name PCD)" for (name, kind) in [
+    ("plain", Val(:plain)),
+    ("centered", Val(:centered)),
+    ("standardized", Val(:standardized)),
+]
+    check_all_zero_pcd(kind)
+end
+
+@testset "all-zero weights fail before mutation (UCD)" begin
+    data = [0.0 1.0; 1.0 0.0]
+    rbm = base_rbm()
+    before = model_state(rbm)
+    init_calls = Ref(0)
+    callbacks = Ref(0)
+
+    @test_throws ArgumentError ucd!(
+        rbm, data;
+        wts = zeros(2), batchsize = 2, iters = 1, nchains = 1,
+        optim = MutatingInitRule(init_calls),
+        callback = (; kwargs...) -> (callbacks[] += 1),
+    )
+    @test model_state(rbm) == before
+    @test iszero(init_calls[])
+    @test iszero(callbacks[])
+end
+
+function train_sparse_pcd!(::Val{:plain}, rbm, data, wts, vm, optim, callback)
+    return pcd!(
+        rbm, data;
+        wts, vm, optim, callback,
+        batchsize = 4, iters = 1, steps = 0,
+        shuffle = false, zerosum = false, rescale = false,
+    )
+end
+
+function train_sparse_pcd!(::Val{:centered}, rbm, data, wts, vm, optim, callback)
+    return pcd!(
+        rbm, data;
+        wts, vm, optim, callback,
+        batchsize = 4, iters = 1, steps = 0,
+        hidden_offset_damping = 0, zerosum = false, rescale = false,
+    )
+end
+
+function train_sparse_pcd!(::Val{:standardized}, rbm, data, wts, vm, optim, callback)
+    return pcd!(
+        rbm, data;
+        wts, vm, optim, callback,
+        batchsize = 4, iters = 1, steps = 0,
+        shuffle = false, damping = 0, ϵv = 1, ϵh = 1,
+        zerosum = false, rescale_hidden = false,
+    )
+end
+
+function train_sparse_default_pcd!(::Val{:plain}, rbm, data, wts, optim, callback)
+    return pcd!(
+        rbm, data;
+        wts, optim, callback,
+        batchsize = 4, iters = 1, steps = 0,
+        shuffle = false, zerosum = false, rescale = false,
+    )
+end
+
+function train_sparse_default_pcd!(::Val{:centered}, rbm, data, wts, optim, callback)
+    return pcd!(
+        rbm, data;
+        wts, optim, callback,
+        batchsize = 4, iters = 1, steps = 0,
+        hidden_offset_damping = 0, zerosum = false, rescale = false,
+    )
+end
+
+function train_sparse_default_pcd!(
+    ::Val{:standardized}, rbm, data, wts, optim, callback,
+)
+    return pcd!(
+        rbm, data;
+        wts, optim, callback,
+        batchsize = 4, iters = 1, steps = 0,
+        shuffle = false, damping = 0, ϵv = 1, ϵh = 1,
+        zerosum = false, rescale_hidden = false,
+    )
+end
+
+@testset "fewer positive samples than batchsize complete ($name PCD)" for (name, kind) in [
+    ("plain", Val(:plain)),
+    ("centered", Val(:centered)),
+    ("standardized", Val(:standardized)),
+]
+    data = [
+        NaN NaN NaN NaN 1.0
+        NaN NaN NaN NaN 0.0
+    ]
+    wts = [0.0, 0.0, 0.0, 0.0, 1.0]
+    rbm = wrap_rbm(kind, base_rbm())
+    vm = falses(2, 4)
+    calls = Ref(0)
+    log = callback_log()
+
+    train_sparse_pcd!(
+        kind, rbm, data, wts, vm, CountingDescent(0.01, calls), log.callback,
+    )
+
+    @test log.iterations == [1]
+    @test length(only(log.weights)) == 1
+    @test all(w -> w > 0, only(log.weights))
+    @test calls[] == 3
+    @test all_finite(rbm)
+
+    default_rbm = wrap_rbm(kind, base_rbm())
+    default_calls = Ref(0)
+    fantasy_sizes = Int[]
+    seed!(107)
+    train_sparse_default_pcd!(
+        kind,
+        default_rbm,
+        data,
+        wts,
+        CountingDescent(0.01, default_calls),
+        (; vm, kwargs...) -> push!(fantasy_sizes, size(vm, ndims(vm))),
+    )
+    @test fantasy_sizes == [1]
+    @test default_calls[] == 3
+end
+
+@testset "fewer positive samples than batchsize complete (UCD)" begin
+    data = [
+        NaN NaN NaN NaN 1.0
+        NaN NaN NaN NaN 0.0
+    ]
+    wts = [0.0, 0.0, 0.0, 0.0, 1.0]
+    rbm = base_rbm()
+    calls = Ref(0)
+    log = callback_log()
+
+    seed!(105)
+    ucd!(
+        rbm, data;
+        wts, batchsize = 4, iters = 1, nchains = 1,
+        min_steps = 1, max_steps = 64, max_resamples = 100,
+        optim = CountingDescent(0.01, calls),
+        callback = log.callback, shuffle = false, zerosum = false, rescale = false,
+    )
+
+    @test log.iterations == [1]
+    @test length(only(log.weights)) == 1
+    @test all(w -> w > 0, only(log.weights))
+    @test calls[] == 3
+    @test all_finite(rbm)
+
+    default_rbm = base_rbm()
+    explicit_rbm = deepcopy(default_rbm)
+    common = (;
+        wts,
+        batchsize = 4,
+        iters = 1,
+        min_steps = 1,
+        max_steps = 64,
+        max_resamples = 100,
+        shuffle = false,
+        zerosum = false,
+        rescale = false,
+    )
+    seed!(108)
+    ucd!(default_rbm, data; common...)
+    seed!(108)
+    ucd!(explicit_rbm, data; common..., nchains = 1)
+    @test model_state(default_rbm) == model_state(explicit_rbm)
+end

--- a/test/zero_weight_training.jl
+++ b/test/zero_weight_training.jl
@@ -346,6 +346,30 @@ end
     @test batch_weight == 1
 end
 
+@testset "narrow mixed-range weights remain positive ($W)" for W in (Float16, Float32)
+    small = nextfloat(zero(W))
+    large = floatmax(W)
+    wts = W[small, large]
+    data = zeros(W, 1, length(wts))
+    A = W === Float16 ? Float32 : Float64
+
+    _, raw_wts, training_wts, normalization, _ =
+        RBMs._prepare_training_data(data, wts; batchsize = 1)
+    @test raw_wts === wts
+    @test eltype(training_wts) === A
+    @test training_wts[1] > 0
+    @test training_wts[2] == 1
+
+    training_batch_wts, batch_weight =
+        RBMs._prepare_training_batch(raw_wts[1:1], normalization)
+    ratio = A(small) / A(large)
+    expected_batch_weight = 2ratio / (1 + ratio)
+    @test eltype(training_batch_wts) === A
+    @test training_batch_wts == [one(A)]
+    @test batch_weight > 0
+    @test batch_weight ≈ expected_batch_weight
+end
+
 function mutation_sensitive_rbm(::Val{:plain})
     return RBM(
         Binary(; θ = [0.1, -0.2]),

--- a/test/zero_weight_training.jl
+++ b/test/zero_weight_training.jl
@@ -239,6 +239,104 @@ end
     end
 end
 
+@testset "finite extreme weights are scale-stable ($name PCD)" for (name, kind, seed) in [
+    ("plain", Val(:plain), 109),
+    ("centered", Val(:centered), 110),
+    ("standardized", Val(:standardized), 111),
+]
+    data = [
+        NaN 0.0 1.0
+        NaN 1.0 0.0
+    ]
+    extreme_wts = [0.0, floatmax(Float64), floatmax(Float64)]
+    unit_wts = [0.0, 1.0, 1.0]
+    extreme_rbm = wrap_rbm(kind, base_rbm())
+    unit_rbm = wrap_rbm(kind, base_rbm())
+    extreme_vm = falses(2, 1)
+    unit_vm = copy(extreme_vm)
+    extreme_log = callback_log()
+    unit_log = callback_log()
+
+    seed!(seed)
+    train_pcd!(
+        kind, extreme_rbm, data, extreme_wts, extreme_vm,
+        CountingDescent(0.01, Ref(0)), extreme_log.callback;
+        iters = 2, batchsize = 1,
+    )
+    seed!(seed)
+    train_pcd!(
+        kind, unit_rbm, data, unit_wts, unit_vm,
+        CountingDescent(0.01, Ref(0)), unit_log.callback;
+        iters = 2, batchsize = 1,
+    )
+
+    @test model_state(extreme_rbm) == model_state(unit_rbm)
+    @test extreme_vm == unit_vm
+    @test extreme_log.weights == [[floatmax(Float64)], [floatmax(Float64)]]
+    @test unit_log.weights == [[1.0], [1.0]]
+    @test all_finite(extreme_rbm)
+end
+
+@testset "finite extreme weights are scale-stable (UCD)" begin
+    data = [
+        NaN 0.0 1.0
+        NaN 1.0 0.0
+    ]
+    extreme_wts = [0.0, floatmax(Float64), floatmax(Float64)]
+    unit_wts = [0.0, 1.0, 1.0]
+    extreme_rbm = base_rbm()
+    unit_rbm = base_rbm()
+    extreme_log = callback_log()
+    unit_log = callback_log()
+    common = (;
+        batchsize = 1,
+        iters = 2,
+        nchains = 1,
+        min_steps = 1,
+        max_steps = 64,
+        max_resamples = 100,
+        shuffle = false,
+        zerosum = false,
+        rescale = false,
+    )
+
+    seed!(112)
+    ucd!(
+        extreme_rbm, data;
+        common..., wts = extreme_wts,
+        optim = CountingDescent(0.01, Ref(0)),
+        callback = extreme_log.callback,
+    )
+    seed!(112)
+    ucd!(
+        unit_rbm, data;
+        common..., wts = unit_wts,
+        optim = CountingDescent(0.01, Ref(0)),
+        callback = unit_log.callback,
+    )
+
+    @test model_state(extreme_rbm) == model_state(unit_rbm)
+    @test extreme_log.weights == [[floatmax(Float64)], [floatmax(Float64)]]
+    @test unit_log.weights == [[1.0], [1.0]]
+    @test all_finite(extreme_rbm)
+end
+
+@testset "Float16 weight normalization uses a safe accumulator" begin
+    data = zeros(Float16, 1, 70_000)
+    wts = ones(Float16, 70_000)
+    _, raw_wts, training_wts, normalization, _ =
+        RBMs._prepare_training_data(data, wts; batchsize = length(wts))
+
+    @test raw_wts === wts
+    @test eltype(training_wts) === Float32
+    @test normalization.mean == 1.0f0
+
+    training_batch_wts, batch_weight =
+        RBMs._prepare_training_batch(raw_wts, normalization)
+    @test eltype(training_batch_wts) === Float32
+    @test batch_weight == 1
+end
+
 function mutation_sensitive_rbm(::Val{:plain})
     return RBM(
         Binary(; θ = [0.1, -0.2]),

--- a/test/zero_weight_training.jl
+++ b/test/zero_weight_training.jl
@@ -239,16 +239,21 @@ end
     end
 end
 
-@testset "finite extreme weights are scale-stable ($name PCD)" for (name, kind, seed) in [
-    ("plain", Val(:plain), 109),
-    ("centered", Val(:centered), 110),
-    ("standardized", Val(:standardized), 111),
-]
+@testset "finite extreme $weight_type weights are scale-stable ($name PCD)" for
+    (name, kind, seed) in [
+        ("plain", Val(:plain), 109),
+        ("centered", Val(:centered), 110),
+        ("standardized", Val(:standardized), 111),
+    ],
+    (weight_type, extreme_weight) in [
+        ("Float64", floatmax(Float64)),
+        ("UInt128", typemax(UInt128)),
+    ]
     data = [
         NaN 0.0 1.0
         NaN 1.0 0.0
     ]
-    extreme_wts = [0.0, floatmax(Float64), floatmax(Float64)]
+    extreme_wts = [zero(extreme_weight), extreme_weight, extreme_weight]
     unit_wts = [0.0, 1.0, 1.0]
     extreme_rbm = wrap_rbm(kind, base_rbm())
     unit_rbm = wrap_rbm(kind, base_rbm())
@@ -272,17 +277,21 @@ end
 
     @test model_state(extreme_rbm) == model_state(unit_rbm)
     @test extreme_vm == unit_vm
-    @test extreme_log.weights == [[floatmax(Float64)], [floatmax(Float64)]]
+    @test extreme_log.weights == [[extreme_weight], [extreme_weight]]
     @test unit_log.weights == [[1.0], [1.0]]
     @test all_finite(extreme_rbm)
 end
 
-@testset "finite extreme weights are scale-stable (UCD)" begin
+@testset "finite extreme $weight_type weights are scale-stable (UCD)" for
+    (weight_type, extreme_weight) in [
+        ("Float64", floatmax(Float64)),
+        ("UInt128", typemax(UInt128)),
+    ]
     data = [
         NaN 0.0 1.0
         NaN 1.0 0.0
     ]
-    extreme_wts = [0.0, floatmax(Float64), floatmax(Float64)]
+    extreme_wts = [zero(extreme_weight), extreme_weight, extreme_weight]
     unit_wts = [0.0, 1.0, 1.0]
     extreme_rbm = base_rbm()
     unit_rbm = base_rbm()
@@ -316,7 +325,7 @@ end
     )
 
     @test model_state(extreme_rbm) == model_state(unit_rbm)
-    @test extreme_log.weights == [[floatmax(Float64)], [floatmax(Float64)]]
+    @test extreme_log.weights == [[extreme_weight], [extreme_weight]]
     @test unit_log.weights == [[1.0], [1.0]]
     @test all_finite(extreme_rbm)
 end


### PR DESCRIPTION
## Summary

- validate weighted training inputs as finite, real, and nonnegative, with at least one positive weight
- remove zero-weight observations before moments, minibatches, chains, wrapper statistics, optimizer work, and callbacks
- make `iters` count completed parameter updates even when zero-weight observations would otherwise form empty batches
- defer default moments, fantasy particles, optimizer state, and UCD chain counts until after validation
- keep weighted training backend-safe on JLArrays/GPUArrays and compatible with Julia 1.10
- document the semantics and add focused regressions for plain, centered, and standardized PCD plus UCD

## Root cause

Weighted minibatch gradients normalized by the minibatch weight before applying the minibatch bias correction. A zero-total minibatch therefore divided by zero and produced NaNs, and the later multiplication by a zero batch factor could not recover them. Zero-weight observations also remained present in minibatch boundaries, wrapper statistics, and UCD chain initialization.

## Validation

- `julia --project=test test/zero_weight_training.jl`
- `julia --project=test test/pcd.jl`
- `julia --project=test test/ucd.jl`
- `julia --project=test test/centered.jl`
- `julia --project=test test/standardized.jl`
- `julia --project=test test/jlarrays.jl` (Julia 1.12 and Julia 1.10 with `allowscalar(false)`)
- `julia --project=. -e 'using Pkg; Pkg.test()'`
- `julia --project=docs docs/make.jl`

Fixes #143
