### PR TITLE
Add complexity guardrails

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -193,11 +193,12 @@ jobs:
               one-paragraph justification of what you checked. If approval
               is rejected for permission reasons, fall back to
               `gh pr review --comment --body "..."` with the same text.
-            - If you confirmed a serious problem (a real bug, data
-              corruption, security issue, or broken API), request changes:
+            - If you confirmed an Important (blocking-severity) finding under
+              REVIEW.md, including substantial avoidable complexity with a
+              concrete simpler alternative, request changes:
               `gh pr review --request-changes --body "..."` summarizing the
-              blocking findings. Reserve this for confirmed, consequential
-              problems — never for uncertainty or taste.
+              blocking findings. Never request changes for uncertainty or
+              taste.
             - Otherwise (minor or uncertain findings only), submit
               `gh pr review --comment --body "..."` with a short summary.
             On re-runs after new commits, submit a fresh verdict; an

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,7 +1,7 @@
 # Claude review of every pull request.
 #
-# Reviews the full PR diff and posts inline review comments for real
-# findings (bugs, correctness, security), then submits a review verdict:
+# Reviews the full PR diff and posts inline review comments for consequential
+# findings (including avoidable complexity), then submits a review verdict:
 # approve when convinced the PR is sound, request changes on serious
 # confirmed problems, comment-only otherwise. What gets flagged and at
 # what severity is governed by REVIEW.md at the repo root, read from the
@@ -160,9 +160,17 @@ jobs:
             part of the diff. If REVIEW.md is missing or unreadable on the
             base branch, fall back to these defaults: report real problems
             only (bugs and logic errors, correctness of math/statistics,
-            API breakage, security issues); do not comment on style,
-            formatting, or preferences; if you find nothing significant,
-            post no inline comments.
+            API breakage, security issues, and substantial avoidable
+            complexity with a concrete simpler alternative); do not comment
+            on style, formatting, or preferences; if you find nothing
+            significant, post no inline comments.
+
+            Actively apply REVIEW.md's complexity guidance. Do not stop once
+            the change appears correct or the deterministic metrics pass:
+            challenge unnecessary abstractions, state paths, sentinel types,
+            dispatch layers, duplication, and indirection. Report complexity
+            only when you can identify the unnecessary structure and a
+            materially simpler design that preserves the required behavior.
 
             Post each finding as an inline comment on the relevant line —
             using mcp__github_inline_comment__create_inline_comment when

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,14 @@ commands, and subsystem-specific edit guidance.
 - Never merge a PR or enable auto-merge unless the repository owner explicitly
   instructs it.
 
+## Review guidelines
+
+- Follow `REVIEW.md` for pull-request reviews. In particular, actively look for
+  avoidable complexity instead of treating correct behavior as sufficient.
+- Treat substantial unnecessary complexity as P1/Important when a materially
+  simpler design satisfies the current requirements. Complexity metrics are a
+  floor, not a substitute for this semantic review.
+
 ## Releases
 
 Use `$register-new-version` for release, registration, tagging, or publishing

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -96,8 +96,9 @@ found is a Nit, lead the summary with "No blocking issues."
 - The version in Project.toml keeps its `-DEV` suffix outside of release
   PRs.
 - Added or changed code does not exceed the deterministic complexity ratchets
-  in `test/complexity.jl`, and any edit to an existing exception lowers or
-  preserves its recorded ceiling rather than raising it.
+  in `test/complexity.jl`. Each exception must identify one existing
+  definition and equal its current measured value; scrutinize and justify any
+  new exception entry, and never use one to grandfather newly added code.
 
 ## Agent-instruction files
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -12,7 +12,8 @@ significant, post no findings.
 ## What Important means here
 
 Reserve Important (blocking-severity) for findings that would make the
-package compute wrong results or break users:
+package compute wrong results, break users, or add substantial avoidable
+complexity that materially raises future change risk:
 
 - Bugs and logic errors: wrong edge-case behavior, or crashes on valid
   input.
@@ -34,9 +35,30 @@ package compute wrong results or break users:
 - Breaking changes to exported API or behavior not reflected in tests and
   in the `## Unreleased` section of CHANGELOG.md.
 - Security issues in changes to CI workflows.
+- New abstractions, state paths, sentinel types, dispatch layers, or duplicated
+  mechanisms that are not needed for the requested behavior when a materially
+  simpler design fits the current requirements. Identify the concrete simpler
+  design that preserves the behavior; do not block on vague discomfort or
+  speculative future simplifications.
 
 Style, naming, refactoring suggestions, and docstring wording are Nit at
 most.
+
+## Complexity review
+
+Actively inspect every changed function and every new abstraction for
+complexity. Ask whether each branch, helper, type, state value, and layer of
+indirection is required now; whether an existing mechanism can carry the same
+behavior; and whether the change spreads one concern across more files or
+execution paths than necessary. Passing the deterministic complexity checks is
+only a floor: they cannot detect unnecessary architecture or diffuse
+complexity.
+
+Report a complexity finding only when you can point to the specific structure
+that is unnecessary and describe a meaningfully simpler alternative that
+preserves the required behavior. A small local simplification is a Nit; a
+substantial avoidable design that makes the code materially harder to reason
+about, test, or change is Important.
 
 ## Verification bar
 
@@ -73,6 +95,9 @@ found is a Nit, lead the summary with "No blocking issues."
   new behavior.
 - The version in Project.toml keeps its `-DEV` suffix outside of release
   PRs.
+- Added or changed code does not exceed the deterministic complexity ratchets
+  in `test/complexity.jl`, and any edit to an existing exception lowers or
+  preserves its recorded ceiling rather than raising it.
 
 ## Agent-instruction files
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CodeComplexity = "6a833b0f-2137-4092-987b-66bce4e6b438"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -27,6 +28,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [compat]
 Adapt = "4.6.1"
 Aqua = "0.8.9"
+CodeComplexity = "0.2"
 Coverage = "1.8.1"
 DelimitedFiles = "1.9.1"
 Distributions = "≥ 0.25"

--- a/test/complexity.jl
+++ b/test/complexity.jl
@@ -1,0 +1,60 @@
+import CodeComplexity as CC
+using Test: @test, @testset
+
+const ROOT = normpath(joinpath(@__DIR__, ".."))
+const SOURCE = joinpath(ROOT, "src")
+
+# These are ratchets for exceptions present on master at 561dd05b, not targets.
+# New definitions must stay at or below the general limits, and these
+# definitions may not get worse. Lower a recorded ceiling when an exception is
+# simplified.
+const CYCLOMATIC_EXCEPTIONS = Dict(
+    ("src/train/ucd.jl", "_maximal_coupling_step") => 13,
+    ("src/train/ucd.jl", "ucd!") => 14,
+)
+const COGNITIVE_EXCEPTIONS = Dict(
+    ("src/train/ucd.jl", "_maximal_coupling_step") => 19,
+    ("src/train/ucd.jl", "ucd!") => 16,
+)
+const ARGUMENT_COUNT_EXCEPTIONS = Dict(
+    ("src/centered.jl", "pcd!") => 17,
+    ("src/standardized.jl", "pcd!") => 23,
+    ("src/train/pcd.jl", "pcd!") => 19,
+    ("src/train/ucd.jl", "ucd!") => 22,
+)
+
+function check_metric(label, metric, limit, exceptions)
+    @testset "$label ≤ $limit" begin
+        for file in CC.measure_directory(metric, SOURCE; max_value = limit)
+            path = replace(relpath(file.path, ROOT), '\\' => '/')
+            for definition in file.functions
+                key = (path, definition.name)
+                ceiling = get(exceptions, key, limit)
+                @testset "$path:$(definition.line) $(definition.name)" begin
+                    @test definition.value ≤ ceiling
+                end
+            end
+        end
+    end
+end
+
+@testset "source complexity ratchets" begin
+    check_metric(
+        "cyclomatic complexity",
+        CC.CyclomaticComplexity(),
+        10,
+        CYCLOMATIC_EXCEPTIONS,
+    )
+    check_metric(
+        "cognitive complexity",
+        CC.CognitiveComplexity(),
+        15,
+        COGNITIVE_EXCEPTIONS,
+    )
+    check_metric(
+        "argument count",
+        CC.ArgumentCountComplexity(),
+        10,
+        ARGUMENT_COUNT_EXCEPTIONS,
+    )
+end

--- a/test/complexity.jl
+++ b/test/complexity.jl
@@ -2,43 +2,67 @@ import CodeComplexity as CC
 using Test: @test, @testset
 
 const ROOT = normpath(joinpath(@__DIR__, ".."))
-const SOURCE = joinpath(ROOT, "src")
+const SOURCE_DIRS = (joinpath(ROOT, "src"), joinpath(ROOT, "ext"))
 
 # These are ratchets for exceptions present on master at 561dd05b, not targets.
 # New definitions must stay at or below the general limits, and these
-# definitions may not get worse. Lower a recorded ceiling when an exception is
-# simplified.
+# definitions must exactly match their recorded values. Lower a recorded value
+# when an exception is simplified, or remove it once it meets the general
+# limit. Lines deliberately identify individual methods rather than granting a
+# raised ceiling to every same-named method in a file.
 const CYCLOMATIC_EXCEPTIONS = Dict(
-    ("src/train/ucd.jl", "_maximal_coupling_step") => 13,
-    ("src/train/ucd.jl", "ucd!") => 14,
+    ("src/train/ucd.jl", 36, "_maximal_coupling_step") => 13,
+    ("src/train/ucd.jl", 172, "ucd!") => 14,
 )
 const COGNITIVE_EXCEPTIONS = Dict(
-    ("src/train/ucd.jl", "_maximal_coupling_step") => 19,
-    ("src/train/ucd.jl", "ucd!") => 16,
+    ("src/train/ucd.jl", 36, "_maximal_coupling_step") => 19,
+    ("src/train/ucd.jl", 172, "ucd!") => 16,
 )
 const ARGUMENT_COUNT_EXCEPTIONS = Dict(
-    ("src/centered.jl", "pcd!") => 17,
-    ("src/standardized.jl", "pcd!") => 23,
-    ("src/train/pcd.jl", "pcd!") => 19,
-    ("src/train/ucd.jl", "ucd!") => 22,
+    ("src/centered.jl", 440, "pcd!") => 17,
+    ("src/standardized.jl", 430, "pcd!") => 23,
+    ("src/train/pcd.jl", 39, "pcd!") => 19,
+    ("src/train/ucd.jl", 172, "ucd!") => 22,
 )
 
-function check_metric(label, metric, limit, exceptions)
-    @testset "$label ≤ $limit" begin
-        for file in CC.measure_directory(metric, SOURCE; max_value = limit)
-            path = replace(relpath(file.path, ROOT), '\\' => '/')
-            for definition in file.functions
-                key = (path, definition.name)
-                ceiling = get(exceptions, key, limit)
-                @testset "$path:$(definition.line) $(definition.name)" begin
-                    @test definition.value ≤ ceiling
-                end
+function source_files()
+    files = String[]
+    for source_dir in SOURCE_DIRS
+        for (dir, _, names) in walkdir(source_dir)
+            for name in names
+                endswith(name, ".jl") && push!(files, joinpath(dir, name))
             end
         end
     end
+    return sort(files)
 end
 
-@testset "source complexity ratchets" begin
+function check_metric(label, metric, limit, exceptions)
+    @testset "$label ≤ $limit" begin
+        measured_violations = Set{Tuple{String, Int, String}}()
+        for filepath in source_files()
+            # Call measure_file directly so analyzer errors fail CI instead of
+            # being logged and skipped by measure_directory.
+            file = CC.measure_file(metric, filepath; max_value = limit)
+            path = replace(relpath(filepath, ROOT), '\\' => '/')
+            for definition in file.functions
+                key = (path, definition.line, definition.name)
+                @testset "$path:$(definition.line) $(definition.name)" begin
+                    @test key ∉ measured_violations
+                    push!(measured_violations, key)
+                    @test haskey(exceptions, key)
+                    if haskey(exceptions, key)
+                        @test definition.value == exceptions[key]
+                    end
+                end
+            end
+        end
+        @test measured_violations == Set(keys(exceptions))
+        @test all(>(limit), values(exceptions))
+    end
+end
+
+@testset "source and extension complexity ratchets" begin
     check_metric(
         "cyclomatic complexity",
         CC.CyclomaticComplexity(),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,4 +26,5 @@ module standardized_tests include("standardized.jl") end
 module nsReLU_tests include("layers/nsReLU.jl") end
 module ais_tests include("ais.jl") end
 module jlarrays_tests include("jlarrays.jl") end
+module complexity_tests include("complexity.jl") end
 module aqua_tests include("aqua.jl") end


### PR DESCRIPTION
## Summary

- add test-only `CodeComplexity.jl` ratchets for cyclomatic complexity (10), cognitive complexity (15), and argument count (10) across both `src/` and `ext/`
- record the few existing exceptions as exact per-definition baselines, so new exceptions, regressions, skipped analyzer inputs, and stale ceilings fail CI
- strengthen `REVIEW.md`, Codex `AGENTS.md` review guidance, and the automated Claude review prompt to challenge substantial avoidable complexity even when code is correct and metric-compliant

## Why

PR #149 was correct and thoroughly tested, but it also showed that correctness-focused review can approve substantially more machinery than the behavior requires. Deterministic metrics provide an enforceable floor; semantic review is still needed for unnecessary abstractions, duplicated state paths, sentinel types, dispatch layers, and diffuse complexity.

A literal CRAP implementation would require reliable function-level coverage mapping that the available Julia tooling does not provide. This instead combines Julia-aware complexity ratchets with the repository's existing Codecov changed-line coverage requirement.

## Impact

CI now rejects new or worsened complexity violations. Existing public training APIs and the two currently complex UCD definitions are ratcheted at their present values rather than grandfathered without bounds. Any simplification must lower or remove its recorded baseline in the same change.

## Validation

- `julia --project=test test/complexity.jl`
- negative checks proving stale baselines and analyzer errors are rejected
- `julia --project=. -e 'using Pkg; Pkg.test()'`
- `uv run .github/scripts/lint_agent_docs.py`
- workflow YAML parse and `git diff --check`

The full Julia suite passed, including all 30 complexity-ratchet assertions and Aqua.