### PR TITLE
Post Claude review results

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,17 +12,16 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Forked pull_request workflows cannot access the OAuth secret or a
+    # write-capable GITHUB_TOKEN. Keep this on pull_request (not
+    # pull_request_target) and only review trusted, same-repository branches.
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -38,7 +37,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Summary

- pass `--comment` to the Claude code-review plugin so clean summaries and findings are visible on pull requests
- grant the workflow token write access to issue comments and pull-request review comments
- skip draft and forked pull requests while retaining the safer `pull_request` event model

## Root cause

The installer-generated workflow invoked the plugin without `--comment` and granted only read permissions. Reviews therefore completed as green checks without publishing their verdict or actionable findings.

This reproduced on #159: both successful `Claude Code Review` runs recorded one permission denial and reported `No buffered inline comments`, while neither run published a review attributable to the workflow.

## Impact

Automatic Claude reviews on trusted same-repository branches can now publish PR-visible results. Forked pull requests remain unable to access the OAuth secret or a write-capable token.

This ports the fix from cossio/claude-skills#64, which closed cossio/claude-skills#62.

## Validation

- workflow YAML parse and configuration assertions — passed
- `git diff --check` — passed
- `actionlint` — not run (not installed locally)