### PR TITLE
Accelerate exact Gaussian-hidden pseudolikelihood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file. The format 
 - Fixed `log_pseudolikelihood(...; exact=true)` for `StandardizedRBM` and
   `CenteredRBM`, whose forwarding methods previously dropped keyword arguments
   and raised a `MethodError` ([#145](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/145)).
+- Accelerated exact `log_pseudolikelihood(...; exact=true)` for RBMs with
+  Gaussian hidden units by evaluating the quadratic Gaussian cumulant
+  analytically instead of recomputing it for every visible-site substitution.
+  The new Binary, Spin, Potts, and PottsGumbel paths preserve multidimensional
+  batches, dense Potts inputs, and GPU-compatible array semantics while
+  substantially reducing runtime and allocations. Exact paths for other
+  hidden layers now reuse their hidden-input buffers, roughly halving allocated
+  memory.
 - Raised the minimum supported ChainRulesCore version to 1.25.2, which fixes an ambiguous `ProjectTo{NoTangent}` call involving thunks during Zygote differentiation.
 - Fixed `pcd!(::StandardizedRBM)` producing non-finite parameters and energies when visible data has zero-variance coordinates, such as constant Binary features or absent Potts categories. Such centered coordinates now use a neutral unit scale; nonconstant coordinates and explicit positive `ϵv` behavior are unchanged ([#139](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/139)).
 - Fixed weighted training in plain, centered, and standardized `pcd!`, and in

--- a/src/pseudolikelihood.jl
+++ b/src/pseudolikelihood.jl
@@ -297,7 +297,9 @@ function _gaussian_hidden_pseudolikelihood_context(
     #
     # Precompute the terms shared by all visible-site substitutions. This turns
     # the repeated hidden cgf evaluations below into matrix multiplications.
-    T = promote_type(eltype(rbm.w), eltype(rbm.hidden.par))
+    T = float(promote_type(
+        eltype(rbm.visible.par), eltype(rbm.hidden.par), eltype(rbm.w)
+    ))
     wflat = convert_eltype(T, flat_w(rbm))
     vcalc = convert_eltype(T, vflat)
     inputs = wflat' * vcalc
@@ -321,7 +323,8 @@ function _log_pseudolikelihood_exact_2states(rbm::RBM, v::AbstractArray, flip::I
         δ .= ifelse.(view(vflat, j, :) .> 0, -flip, flip)
         Inew .= Iflat .+ view(wflat, j, :) .* reshape(δ, 1, B)
         Γ1 = vec(cgf(rbm.hidden, reshape(Inew, size(rbm.hidden)..., B)))
-        lPL .-= log1pexp.(view(θflat, j:j) .* δ .+ Γ1 .- Γ0)
+        Γ1 .-= Γ0
+        lPL .-= log1pexp.(view(θflat, j:j) .* δ .+ Γ1)
     end
     lPL ./= length(rbm.visible)
     return reshape(lPL, batch_sz)
@@ -381,7 +384,8 @@ function log_pseudolikelihood_exact(rbm::RBM{<:Potts}, v::AbstractArray)
         for x in 1:q
             Inew .= Iflat .+ (view(Wsite, x, :) .- Wold)
             Γx = vec(cgf(rbm.hidden, reshape(Inew, size(rbm.hidden)..., B)))
-            minusΔF[x, :] .= view(θsite, x:x) .- θold .+ Γx .- Γ0
+            Γx .-= Γ0
+            minusΔF[x, :] .= view(θsite, x:x) .- θold .+ Γx
         end
         lPL .-= vec(logsumexp(minusΔF; dims=1))
     end
@@ -401,7 +405,8 @@ function log_pseudolikelihood_exact(
     θflat = convert_eltype(eltype(linear), vec(rbm.visible.θ))
     lPL = zero(similar(linear, B))
     logits = similar(linear, q, B)
-    wscaled_site = similar(wflat, q, length(rbm.hidden))
+    wscaled_site = similar(linear, q, length(rbm.hidden))
+    current = similar(linear, B)
 
     for j in 1:nsites
         rows = ((j - 1) * q + 1):(j * q)
@@ -418,17 +423,16 @@ function log_pseudolikelihood_exact(
         #   θ_x + w_x' * (z / |γ|) + w_x' * (w_x / |γ|) / 2
         #       - w_x' * (Wsite' * vsite / |γ|).
         #
-        # Keep the x-independent term explicitly so this remains correct for
-        # dense Potts inputs as well as the usual one-hot representation.
-        current = vec(sum(
-            Vsite .* (
-                reshape(θsite, q, 1) .+ linear_site .- gram_v ./ 2
-            );
-            dims=1,
-        ))
-        logits .= reshape(θsite, q, 1) .+ linear_site .+
-            reshape(LinearAlgebra.diag(gram), q, 1) ./ 2 .- gram_v
-        logits .-= reshape(current, 1, B)
+        # Subtract x-independent terms before adding the visible fields. This
+        # preserves small field differences when the hidden contribution has a
+        # large common offset. Keep all three dense-input corrections explicit.
+        current .= vec(sum(Vsite .* linear_site; dims=1))
+        logits .= linear_site .- reshape(current, 1, B)
+        current .= vec(sum(Vsite .* reshape(θsite, q, 1); dims=1))
+        logits .+= reshape(θsite, q, 1) .- reshape(current, 1, B)
+        current .= vec(sum(Vsite .* gram_v; dims=1))
+        logits .+= reshape(LinearAlgebra.diag(gram), q, 1) ./ 2 .- gram_v .+
+            reshape(current, 1, B) ./ 2
         lPL .-= vec(logsumexp(logits; dims=1))
     end
     lPL ./= nsites

--- a/src/pseudolikelihood.jl
+++ b/src/pseudolikelihood.jl
@@ -284,6 +284,30 @@ function log_pseudolikelihood_sites(
     return log_pseudolikelihood_sites(RBM(Potts(rbm.visible), rbm.hidden, rbm.w), v, sites)
 end
 
+function _gaussian_hidden_pseudolikelihood_context(
+    rbm::RBM{<:AbstractLayer,<:Gaussian}, v::AbstractArray
+)
+    batch_sz = batch_size(rbm.visible, v)
+    B = prod(batch_sz)
+    vflat = reshape(v, length(rbm.visible), B)
+
+    # The Gaussian cgf is quadratic. Its change under a hidden-input shift u is
+    #
+    #   Γ(z + u) - Γ(z) = u' * (z / |γ|) + u' * (u / |γ|) / 2.
+    #
+    # Precompute the terms shared by all visible-site substitutions. This turns
+    # the repeated hidden cgf evaluations below into matrix multiplications.
+    T = promote_type(eltype(rbm.w), eltype(rbm.hidden.par))
+    wflat = convert_eltype(T, flat_w(rbm))
+    vcalc = convert_eltype(T, vflat)
+    inputs = wflat' * vcalc
+    θh = convert_eltype(T, vec(rbm.hidden.θ))
+    γh = convert_eltype(T, vec(rbm.hidden.γ))
+    invγ = inv.(abs.(γh))
+    hidden_mean = (θh .+ inputs) .* reshape(invγ, length(rbm.hidden), 1)
+    return batch_sz, B, vcalc, wflat, invγ, hidden_mean
+end
+
 function _log_pseudolikelihood_exact_2states(rbm::RBM, v::AbstractArray, flip::Integer)
     @assert size(rbm.visible) == size(v)[1:ndims(rbm.visible)]
     batch_sz, B, vB, Iflat, Γ0 = _pseudolikelihood_context(rbm, v)
@@ -291,13 +315,39 @@ function _log_pseudolikelihood_exact_2states(rbm::RBM, v::AbstractArray, flip::I
     wflat = flat_w(rbm)
     θflat = vec(rbm.visible.θ)
     lPL = zero(Γ0)
+    δ = similar(Γ0)
+    Inew = similar(Iflat)
     for j in 1:length(rbm.visible)
-        δ = ifelse.(view(vflat, j, :) .> 0, -flip, flip)
-        Inew = Iflat .+ view(wflat, j, :) .* reshape(δ, 1, B)
+        δ .= ifelse.(view(vflat, j, :) .> 0, -flip, flip)
+        Inew .= Iflat .+ view(wflat, j, :) .* reshape(δ, 1, B)
         Γ1 = vec(cgf(rbm.hidden, reshape(Inew, size(rbm.hidden)..., B)))
-        ΔF = .-view(θflat, j:j) .* δ .- (Γ1 .- Γ0)
-        lPL .-= log1pexp.(.-ΔF)
+        lPL .-= log1pexp.(view(θflat, j:j) .* δ .+ Γ1 .- Γ0)
     end
+    lPL ./= length(rbm.visible)
+    return reshape(lPL, batch_sz)
+end
+
+function _log_pseudolikelihood_exact_2states(
+    rbm::RBM{<:Union{Binary,Spin},<:Gaussian}, v::AbstractArray, flip::Integer
+)
+    @assert size(rbm.visible) == size(v)[1:ndims(rbm.visible)]
+    batch_sz, _, vflat, wflat, invγ, hidden_mean =
+        _gaussian_hidden_pseudolikelihood_context(rbm, v)
+    T = eltype(wflat)
+    flipT = convert(T, flip)
+    θv = reshape(convert_eltype(T, vec(rbm.visible.θ)), length(rbm.visible), 1)
+    wscaled = wflat .* reshape(invγ, 1, length(rbm.hidden))
+    linear = wflat * hidden_mean
+    quadratic = vec(mapreduce(*, +, wscaled, wflat; dims=2))
+    quadratic ./= 2
+    quadratic = reshape(quadratic, length(rbm.visible), 1)
+
+    # If δ is the change of a visible unit, then
+    # -ΔF = δ * (θv + W * (z / |γ|)) + δ² * diag(W / |γ| * W') / 2.
+    minusΔF = linear
+    @. minusΔF = (θv + minusΔF) * ifelse(vflat > 0, -flipT, flipT) +
+        quadratic * abs2(flipT)
+    lPL = vec(sum(.-log1pexp.(minusΔF); dims=1))
     lPL ./= length(rbm.visible)
     return reshape(lPL, batch_sz)
 end
@@ -318,8 +368,9 @@ function log_pseudolikelihood_exact(rbm::RBM{<:Potts}, v::AbstractArray)
     vflat = reshape(vB, length(rbm.visible), B)
     wflat = flat_w(rbm)
     θflat = vec(rbm.visible.θ)
-    ΔF = similar(Γ0, q, B)
+    minusΔF = similar(Γ0, q, B)
     lPL = zero(Γ0)
+    Inew = similar(Iflat)
     for j in 1:nsites
         rows = ((j - 1) * q + 1):(j * q)
         Vsite = with_eltype_of(wflat, view(vflat, rows, :)) # q × B, one-hot columns
@@ -328,11 +379,57 @@ function log_pseudolikelihood_exact(rbm::RBM{<:Potts}, v::AbstractArray)
         Wold = Wsite' * Vsite # M × B
         θold = Vsite' * θsite # B
         for x in 1:q
-            Inew = Iflat .+ (view(Wsite, x, :) .- Wold)
+            Inew .= Iflat .+ (view(Wsite, x, :) .- Wold)
             Γx = vec(cgf(rbm.hidden, reshape(Inew, size(rbm.hidden)..., B)))
-            ΔF[x, :] .= θold .- view(θsite, x:x) .- (Γx .- Γ0)
+            minusΔF[x, :] .= view(θsite, x:x) .- θold .+ Γx .- Γ0
         end
-        lPL .-= vec(logsumexp(.-ΔF; dims=1))
+        lPL .-= vec(logsumexp(minusΔF; dims=1))
+    end
+    lPL ./= nsites
+    return reshape(lPL, batch_sz)
+end
+
+function log_pseudolikelihood_exact(
+    rbm::RBM{<:Potts,<:Gaussian}, v::AbstractArray
+)
+    @assert size(rbm.visible) == size(v)[1:ndims(rbm.visible)]
+    batch_sz, B, vflat, wflat, invγ, hidden_mean =
+        _gaussian_hidden_pseudolikelihood_context(rbm, v)
+    q = colors(rbm.visible)
+    nsites = prod(sitesize(rbm.visible))
+    linear = wflat * hidden_mean
+    θflat = convert_eltype(eltype(linear), vec(rbm.visible.θ))
+    lPL = zero(similar(linear, B))
+    logits = similar(linear, q, B)
+    wscaled_site = similar(wflat, q, length(rbm.hidden))
+
+    for j in 1:nsites
+        rows = ((j - 1) * q + 1):(j * q)
+        Vsite = view(vflat, rows, :)
+        Wsite = view(wflat, rows, :)
+        wscaled_site .= Wsite .* reshape(invγ, 1, length(rbm.hidden))
+        gram = wscaled_site * Wsite'
+        gram_v = gram * Vsite
+        θsite = view(θflat, rows)
+        linear_site = view(linear, rows, :)
+
+        # Up to an x-independent term, -ΔF_x is the conditional logit
+        #
+        #   θ_x + w_x' * (z / |γ|) + w_x' * (w_x / |γ|) / 2
+        #       - w_x' * (Wsite' * vsite / |γ|).
+        #
+        # Keep the x-independent term explicitly so this remains correct for
+        # dense Potts inputs as well as the usual one-hot representation.
+        current = vec(sum(
+            Vsite .* (
+                reshape(θsite, q, 1) .+ linear_site .- gram_v ./ 2
+            );
+            dims=1,
+        ))
+        logits .= reshape(θsite, q, 1) .+ linear_site .+
+            reshape(LinearAlgebra.diag(gram), q, 1) ./ 2 .- gram_v
+        logits .-= reshape(current, 1, B)
+        lPL .-= vec(logsumexp(logits; dims=1))
     end
     lPL ./= nsites
     return reshape(lPL, batch_sz)

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -186,6 +186,39 @@ end
     end
 end
 
+@testset "Gaussian-hidden exact pseudolikelihood" begin
+    T = Float32
+    batch = (2, 3)
+    hidden_size = (2, 2)
+    hidden = Gaussian(
+        ; θ = randn(T, hidden_size...),
+        γ = reshape(T[-2, -0.7, 1.1, 2.3], hidden_size),
+    )
+    potts_visible = Potts(; θ = randn(T, Q, N...))
+    v_potts = sample_from_inputs(
+        potts_visible, zeros(T, Q, N..., batch...)
+    )
+    cases = (
+        (Binary(; θ = randn(T, N...)), bitrand(N..., batch...)),
+        (Spin(; θ = randn(T, N...)), rand((Int8(-1), Int8(1)), N..., batch...)),
+        (potts_visible, v_potts),
+        (PottsGumbel(potts_visible.par), v_potts),
+    )
+
+    for (visible, v) in cases
+        w = randn(T, size(visible)..., hidden_size...) / sqrt(T(length(visible)))
+        rbm = RBM(visible, hidden, w)
+        expected = log_pseudolikelihood(rbm, v; exact = true)
+        jl_rbm = adapt(JLArray, rbm)
+        jl_v = JLArray(v)
+        result = log_pseudolikelihood(jl_rbm, jl_v; exact = true)
+        @test result isa JLArray
+        @test eltype(result) == T
+        @test size(result) == batch
+        @test adapt(Array, result) ≈ expected rtol = 5e-4 atol = 5e-5
+    end
+end
+
 @testset "gauge transformations" begin
     rbm = RBM(
         Potts(; θ = randn(Q, N...)),

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -217,6 +217,34 @@ end
         @test size(result) == batch
         @test adapt(Array, result) ≈ expected rtol = 5e-4 atol = 5e-5
     end
+
+    θ_offset = T[0, 1, -1, 0.5]
+    offset_rbm = RBM(
+        Potts(; θ = reshape(θ_offset, Q, 1)),
+        Gaussian(; θ = T[1e8], γ = T[-1]),
+        ones(T, Q, 1, 1),
+    )
+    offset_v = reshape(Bool[1, 0, 0, 0], Q, 1)
+    offset_result = log_pseudolikelihood(
+        adapt(JLArray, offset_rbm), JLArray(offset_v); exact = true
+    )
+    @test offset_result isa JLArray
+    @test only(adapt(Array, offset_result)) ≈
+        θ_offset[1] - log(sum(exp, θ_offset))
+
+    mixed_rbm = RBM(
+        Potts(; θ = reshape(Float64[1e8, 1e8 + 1, 1e8 - 1, 1e8 + 0.5], Q, 1)),
+        Gaussian(; θ = Float32[0], γ = Float32[1]),
+        zeros(Float32, Q, 1, 1),
+    )
+    mixed_v = reshape(Bool[1, 0, 0, 0], Q, 1)
+    mixed_result = log_pseudolikelihood(
+        adapt(JLArray, mixed_rbm), JLArray(mixed_v); exact = true
+    )
+    @test mixed_result isa JLArray
+    @test eltype(mixed_result) == Float64
+    @test adapt(Array, mixed_result) ≈
+        log_pseudolikelihood(mixed_rbm, mixed_v; exact = true) rtol = 0 atol = 1e-8
 end
 
 @testset "gauge transformations" begin

--- a/test/pseudolikelihood.jl
+++ b/test/pseudolikelihood.jl
@@ -215,7 +215,8 @@ end
 
     # Normalize relative logits before logsumexp. Otherwise, a large common
     # term can erase the conditional normalization in finite precision.
-    visible = Potts(; θ = zeros(T, q, 1))
+    θ_offset = T[0, 1, -1]
+    visible = Potts(; θ = reshape(θ_offset, q, 1))
     hidden_offset = Gaussian(; θ = T[1e8], γ = T[-1])
     rbm_offset = RBM(visible, hidden_offset, ones(T, q, 1, 1))
     for v in (
@@ -224,14 +225,68 @@ end
     )
         reference = invoke(
             log_pseudolikelihood_exact,
-            Tuple{RBM,AbstractArray},
+            Tuple{RBM{<:Potts},AbstractArray},
             rbm_offset,
             v,
         )
         result = log_pseudolikelihood_exact(rbm_offset, v)
-        @test only(reference) ≈ -log(T(q))
+        expected = sum(v .* visible.θ) - logsumexp(θ_offset)
+        @test only(reference) ≈ expected
         @test result ≈ reference
     end
+
+    # Mixed-precision models retain visible fields that are finer than the
+    # weights and hidden parameters.
+    hidden_mixed = Gaussian(; θ = Float32[0], γ = Float32[1])
+    mixed_cases = (
+        (
+            Binary(; θ = Float64[1e8 + 1]),
+            reshape([false], 1),
+            zeros(Float32, 1, 1),
+        ),
+        (
+            Spin(; θ = Float64[5e7 + 0.5]),
+            reshape(Int8[-1], 1),
+            zeros(Float32, 1, 1),
+        ),
+        (
+            Potts(; θ = reshape(Float64[1e8, 1e8 + 1, 1e8 - 1], q, 1)),
+            reshape(Bool[1, 0, 0], q, 1),
+            zeros(Float32, q, 1, 1),
+        ),
+        (
+            PottsGumbel(; θ = reshape(Float64[1e8, 1e8 + 1, 1e8 - 1], q, 1)),
+            reshape(Bool[1, 0, 0], q, 1),
+            zeros(Float32, q, 1, 1),
+        ),
+    )
+    for (visible_mixed, v, w) in mixed_cases
+        rbm_mixed = RBM(visible_mixed, hidden_mixed, w)
+        reference = invoke(
+            log_pseudolikelihood_exact, Tuple{RBM,AbstractArray}, rbm_mixed, v
+        )
+        result = log_pseudolikelihood_exact(rbm_mixed, v)
+        @test eltype(result) == Float64
+        @test result ≈ reference rtol = 0 atol = 1e-8
+    end
+
+    # Integer parameters are valid even though inverse Gaussian precisions are
+    # fractional.
+    rbm_integer = RBM(
+        Potts(; θ = zeros(Int, q, 1)),
+        Gaussian(; θ = Int[0], γ = Int[2]),
+        reshape(Int[0, 1, 2], q, 1, 1),
+    )
+    v_integer = reshape(Bool[1, 0, 0], q, 1)
+    reference = invoke(
+        log_pseudolikelihood_exact,
+        Tuple{RBM{<:Potts},AbstractArray},
+        rbm_integer,
+        v_integer,
+    )
+    result = log_pseudolikelihood_exact(rbm_integer, v_integer)
+    @test eltype(result) == Float64
+    @test result ≈ reference
 end
 
 @testset "stochastic log_pseudolikelihood" begin

--- a/test/pseudolikelihood.jl
+++ b/test/pseudolikelihood.jl
@@ -120,20 +120,22 @@ end
 
 # The specialized fast paths for Binary/Spin/Potts must agree with the generic
 # reference implementation based on substitution matrices.
-@testset "generic fallback vs fast path ($vis)" for vis in (:Binary, :Spin, :Potts)
+@testset "generic fallback vs fast path ($vis, $hid)" for
+    vis in (:Binary, :Spin, :Potts), hid in (:Gaussian, :Binary)
     q = 3
     n = (3, 2)
     m = (2,)
     B = 4
+    hidden = hid === :Gaussian ? Gaussian(m) : Binary(m)
 
     if vis === :Binary
-        rbm = RBM(Binary(n), Gaussian(m), randn(n..., m...) / √prod(n))
+        rbm = RBM(Binary(n), hidden, randn(n..., m...) / √prod(n))
         v = bitrand(n..., B)
     elseif vis === :Spin
-        rbm = RBM(Spin(n), Gaussian(m), randn(n..., m...) / √prod(n))
+        rbm = RBM(Spin(n), hidden, randn(n..., m...) / √prod(n))
         v = rand((-1, +1), n..., B)
     else
-        rbm = RBM(Potts((q, n...)), Gaussian(m), randn(q, n..., m...) / sqrt(q * prod(n)))
+        rbm = RBM(Potts((q, n...)), hidden, randn(q, n..., m...) / sqrt(q * prod(n)))
         v = onehot_encode(rand(1:q, n..., B), 1:q)
     end
     sites = [rand(CartesianIndices(n)) for _ in 1:B]
@@ -147,6 +149,89 @@ end
 
     lpl_exact_generic = invoke(log_pseudolikelihood_exact, Tuple{RBM, AbstractArray}, rbm, v)
     @test lpl_exact_generic ≈ log_pseudolikelihood_exact(rbm, v)
+end
+
+@testset "Gaussian-hidden exact fast paths" begin
+    T = Float32
+    n = (2, 2)
+    m = (2, 2)
+    batch = (2, 3)
+    q = 3
+    hidden = Gaussian(
+        ; θ = randn(T, m...), γ = reshape(T[-2, -0.7, 1.1, 2.3], m)
+    )
+    v_potts = onehot_encode(rand(1:q, n..., batch...), 1:q)
+
+    cases = (
+        (Binary(; θ = randn(T, n...)), bitrand(n..., batch...)),
+        (Spin(; θ = randn(T, n...)), rand((Int8(-1), Int8(1)), n..., batch...)),
+        (Potts(; θ = randn(T, q, n...)), v_potts),
+        (PottsGumbel(; θ = randn(T, q, n...)), v_potts),
+    )
+
+    for (visible, v) in cases
+        w = randn(T, size(visible)..., m...) / sqrt(T(length(visible)))
+        rbm = RBM(visible, hidden, w)
+        reference = invoke(
+            log_pseudolikelihood_exact, Tuple{RBM,AbstractArray}, rbm, v
+        )
+        result = log_pseudolikelihood_exact(rbm, v)
+        @test size(result) == batch
+        @test eltype(result) == T
+        @test result ≈ reference rtol = 5e-4 atol = 5e-5
+    end
+
+    # The optimized Potts formula preserves the generic implementation's
+    # behavior for dense site vectors, not only the usual one-hot inputs.
+    visible = Potts(; θ = randn(T, q, n...))
+    rbm = RBM(
+        visible,
+        hidden,
+        randn(T, q, n..., m...) / sqrt(T(q * prod(n))),
+    )
+    v_dense = rand(T, q, n..., batch...)
+    v_dense ./= sum(v_dense; dims=1)
+    reference = invoke(
+        log_pseudolikelihood_exact, Tuple{RBM,AbstractArray}, rbm, v_dense
+    )
+    @test log_pseudolikelihood_exact(rbm, v_dense) ≈
+        reference rtol = 5e-4 atol = 5e-5
+
+    v_unbatched = bitrand(n...)
+    rbm_unbatched = RBM(
+        Binary(; θ = randn(T, n...)),
+        hidden,
+        randn(T, n..., m...) / sqrt(T(prod(n))),
+    )
+    result = log_pseudolikelihood_exact(rbm_unbatched, v_unbatched)
+    reference = invoke(
+        log_pseudolikelihood_exact,
+        Tuple{RBM,AbstractArray},
+        rbm_unbatched,
+        v_unbatched,
+    )
+    @test size(result) == ()
+    @test only(result) ≈ only(reference) rtol = 5e-4 atol = 5e-5
+
+    # Normalize relative logits before logsumexp. Otherwise, a large common
+    # term can erase the conditional normalization in finite precision.
+    visible = Potts(; θ = zeros(T, q, 1))
+    hidden_offset = Gaussian(; θ = T[1e8], γ = T[-1])
+    rbm_offset = RBM(visible, hidden_offset, ones(T, q, 1, 1))
+    for v in (
+        onehot_encode(reshape([1], 1, 1), 1:q),
+        reshape(T[0.2, 0.3, 0.5], q, 1, 1),
+    )
+        reference = invoke(
+            log_pseudolikelihood_exact,
+            Tuple{RBM,AbstractArray},
+            rbm_offset,
+            v,
+        )
+        result = log_pseudolikelihood_exact(rbm_offset, v)
+        @test only(reference) ≈ -log(T(q))
+        @test result ≈ reference
+    end
 end
 
 @testset "stochastic log_pseudolikelihood" begin


### PR DESCRIPTION
## Summary

- evaluate the quadratic Gaussian hidden cumulant analytically for exact Binary, Spin, Potts, and PottsGumbel pseudolikelihood
- retain multidimensional batches, unbatched inputs, dense Potts inputs, signed `γ` semantics, Float32/Float64 and mixed-precision behavior, integer parameters, and generic array backends
- scale only one Potts site's weights at a time, avoiding a second full weight-sized temporary
- reuse hidden-input buffers in the generic non-Gaussian exact paths
- form Potts relative logits before adding visible-field differences, avoiding precision loss under large common hidden offsets

## Evaluation and design

For Gaussian hidden units,

```text
Γ(z + u) - Γ(z) = u' (z / |γ|) + 1/2 u' (u / |γ|).
```

The retained implementation shares the hidden mean and uses matrix products for the visible conditional fields. Binary and Spin remain fully vectorized. A fully streaming Binary formulation reduced allocation only modestly but was 10–29× slower at moderate/large sizes, so it was rejected. Potts keeps the global field product but builds the scaled weights and Gram matrix one site at a time. Relative hidden, visible-field, and dense-input terms are accumulated separately so small visible-field differences are not added to a large common hidden contribution.

The generic buffer-reuse edits are independently useful: across Binary-Binary and Potts-Binary cases they reduce allocated bytes by 42–50% (1.73–1.99×) with essentially neutral to slightly improved runtime (1.00–1.01×). Cumulant differences are formed before visible-field terms, preserving the original numerical ordering while retaining buffer reuse.

## Benchmarks

Methodology: Julia 1.12.6 on `znver5`, one Julia thread and one BLAS thread, deterministic warmed inputs, adaptive repeated calls, median wall time, and `Base.@allocated`. `old` recreates the exact specialized loops from `origin/master`; `fast` is commit `5641606b`. Float32 is used unless noted.

| workload | old time | fast time | speedup | old alloc | fast alloc | alloc reduction |
|---|---:|---:|---:|---:|---:|---:|
| Binary N=784, M=256, B=256 | 285.9 ms | 5.07 ms | 56.4× | 416.0 MB | 4.54 MB | 91.5× |
| Spin N=256, M=128, B=128 | 25.2 ms | 0.675 ms | 37.3× | 34.5 MB | 0.790 MB | 43.7× |
| Potts q=21, N=100, M=256, B=64 | 192.5 ms | 2.34 ms | 82.2× | 285.0 MB | 3.85 MB | 74.0× |
| dense Potts Float64 q=5, N=64, M=128, B=64 | 20.9 ms | 0.503 ms | 41.6× | 46.9 MB | 1.25 MB | 37.4× |

No runtime crossover regression appeared in the scans:

- Binary Float32/Float64, N=1…256, M=64, B=1/32: 1.7–24.0× faster
- Potts Float32, q=3 with N=1…128 and q=21 with N=1…32, M=64, B=1/32: 1.7–27.5× faster
- against the generic substitution-matrix reference on small cases: 2.9–16.0× faster with 2.1–13.6× lower allocation

## Correctness and numerical stability

The optimized results were compared directly with the generic substitution-matrix implementation for Binary, Spin, Potts, and PottsGumbel visible layers with Gaussian hidden units across:

- Float32 and Float64
- multidimensional `(2, 3)` batches and unbatched inputs
- one-hot and dense Potts inputs
- multidimensional hidden layers
- nontrivial positive and negative `γ`
- high-curvature signed-`γ` stress cases
- Float64 visible fields with Float32 weights/hidden parameters
- integer weights and Gaussian parameters with fractional inverse precision
- JLArrays with scalar indexing disabled

Maximum scaled differences were below `4e-7` for ordinary Float32 cases and below `8e-16` for Float64. A stress case with `|γ| = 1e-3` remained finite and agreed within `2.3e-7` scaled error in Float32.

Review found three edge cases in the initial PR revision, all fixed in `5641606b`:

1. Float32 Potts fields `[0, 1, -1]` under a `1e8` common hidden contribution were rounded away, returning `-log(3)` instead of `-1.4076059`. Relative hidden terms are now formed before visible fields.
2. Float64 visible fields could be downcast when weights and hidden parameters were Float32. The Gaussian calculation type now includes visible parameters.
3. Integer Potts weights with `γ = 2` attempted to store `1/2`-scaled weights in an integer buffer. Gaussian calculations now use a floating promoted type and allocate temporaries from the computed linear result.

Regression coverage includes Binary, Spin, Potts, and PottsGumbel mixed precision, one-hot and dense large-offset Potts inputs, integer Potts parameters, and CPU/JLArray backends.

## Validation

- `julia --project=test test/pseudolikelihood.jl`
- `julia --project=test test/jlarrays.jl`
- extended reference matrix: 72 CPU assertions, 96 JLArrays assertions, and 12 signed-`γ` stress assertions
- `julia --project=. -e 'using Pkg; Pkg.test()'`

All passed on Julia 1.12.6. The branch is rebased onto current `origin/master` (`e77b1b24`).