### PR TITLE
Simplify package release workflow

### DIFF
--- a/.claude/skills/register-new-version/SKILL.md
+++ b/.claude/skills/register-new-version/SKILL.md
@@ -1,34 +1,35 @@
 ---
 name: register-new-version
-description: Release a new version of RestrictedBoltzmannMachines.jl and register it in the Julia General registry, suggesting a semver-correct version number from the changes since the last release. Use when asked to release, register, tag, or publish a new package version.
+description: Release a new version of RestrictedBoltzmannMachines.jl and register it in the Julia General registry, suggesting a ColPrac-compliant version number while leaving the final version decision to the user. Use when asked to release, register, tag, or publish a new package version.
 ---
 
 # Releasing a new version
 
 During development the version in Project.toml carries a `-DEV` suffix (e.g. `5.4.0-DEV`), and changes accumulate under an `## Unreleased` section in CHANGELOG.md.
 
-## Choosing the version number (semver)
+## Choosing the version number (ColPrac semver)
 
-Before anything else, determine the right version number and confirm it with the user:
+Before anything else, analyze the changes and ask the user to choose the version. Never make the final version decision for the user.
 
-1. Review the actual changes since the last registered version — the `## Unreleased` CHANGELOG entries **and** the commit history/diff since the previous release tag (`git log vLAST..master`), since the CHANGELOG may be incomplete. Classify them:
-   - **Breaking** (removed/renamed exported names, changed signatures, semantics or return types of existing public API, dropped Julia/package compat) → bump **major**.
-   - **New features** (new exported functions/types/methods, new keyword options, new capabilities — even small ones) → bump **minor**.
-   - **Bug fixes / internal changes only** (fixes, performance, docs, tests, CI) → bump **patch**.
-   Note the `-DEV` version in Project.toml is only a hint of what was anticipated, not authoritative — e.g. `5.6.1-DEV` may still have accumulated features that warrant `5.7.0`.
-2. Suggest the resulting number to the user, with a one-line justification citing the entries that drive the bump, and get their confirmation.
-3. If the **user** proposes a number, still perform the same review rather than accepting it blindly: check it against the changes, and if it doesn't follow semver (e.g. a patch bump when exported behavior changed, or a major bump for pure fixes), push back once — explain which changes conflict with it and ask them to confirm or revise. The user's decision is final: once they confirm a number after seeing your assessment, proceed with it without further debate. (Borderline calls — e.g. whether a bug-fix-driven behavior change counts as breaking — are likewise the user's to make; your job is only to surface them.)
+1. Review the actual changes since the last registered version — the `## Unreleased` CHANGELOG entries **and** the commit history/diff since the previous release tag (`git log vLAST..master`), since the CHANGELOG may be incomplete.
+2. Classify every change using [ColPrac's extension of SemVer for Julia packages](https://docs.sciml.ai/ColPrac/stable/#Guidance-on-Package-Releases):
+   - **Post-1.0:** bump major for breaking changes, minor for non-breaking features, and patch for bug fixes.
+   - **Pre-1.0:** bump minor for breaking changes and patch for every non-breaking feature or bug fix.
+   - Treat all documented APIs as public, including unexported names documented for normal use. Introducing a deprecation is non-breaking; removing one is breaking.
+   - Treat dependency or Julia compatibility changes as non-breaking features, unless a dependency API exposed through this package makes the user-facing change breaking. Treat a compatibility change made solely to fix a bug as a bug fix.
+   - Treat a correction to clearly broken behavior as a bug fix even when behavior changes incompatibly. Do not classify internal implementation changes, replacing an exception with non-error behavior, unspecified exception types or messages, floating-point details, new exports or supertypes, or textual representations as breaking solely for that reason.
+3. Derive one suggested version from the highest bump required by the accumulated changes. Treat the `-DEV` version in Project.toml only as a hint — e.g. `5.6.1-DEV` may have accumulated features that suggest `5.7.0`.
+4. Present the suggestion with a brief explanation identifying the changes that drive the bump, then ask the user to confirm it or choose another version. Do not edit release files, commit, push, or trigger registration until the user explicitly chooses the final version.
+5. If the **user** proposes a number, still perform the same review rather than accepting it blindly. If it conflicts with ColPrac, push back once with a brief explanation and ask them to confirm or revise. The user's decision is always final, including for borderline classifications.
 
 ## Procedure
 
-1. **Release commit.** Make a single commit titled `vX.Y.Z` that drops the `-DEV` suffix from `version` in Project.toml and renames the `## Unreleased` CHANGELOG section to `## X.Y.Z`. Land it on `master` (directly, or via a PR like [#123](https://github.com/cossio/RestrictedBoltzmannMachines.jl/pull/123)).
+1. **Release commit.** After the user explicitly chooses `X.Y.Z`, make a single commit titled `vX.Y.Z` that drops the `-DEV` suffix from `version` in Project.toml and renames the `## Unreleased` CHANGELOG section to `## X.Y.Z`. Land it on `master` (directly, or via a PR like [#123](https://github.com/cossio/RestrictedBoltzmannMachines.jl/pull/123)).
 
-2. **Frozen registration branch.** Create a branch `release-X.Y.Z` pointing at the master commit that contains the release (the merge commit if it landed via PR) and push it: `git push origin <sha>:refs/heads/release-X.Y.Z`. Never commit to this branch — its whole point is that its HEAD *is* the release commit, so registration targets the exact commit even if master keeps moving in the meantime. (A comment on the release commit itself would pin the SHA with no branch needed — v5.3.2 was released that way — and remains a valid manual fallback for a human with `gh`: `gh api repos/cossio/RestrictedBoltzmannMachines.jl/commits/<sha>/comments -f body="..."`. We dropped commit comments because some cloud sandboxes cannot post them, while issue comments work generically from cloud sessions, local machines, or a browser, so the branch+issue flow is the portable default.)
+2. **Trigger Registrator on the release commit.** Push the release commit, open that exact commit on GitHub (the merge commit if the release landed via PR), and post this comment directly on it:
 
-3. **Trigger Registrator.** Comment on issue [#124 "Julia registration"](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/124) — the single permanent issue used for all registrations, kept closed on purpose so it doesn't pollute the issue list (comments on closed issues still trigger Registrator; do NOT open a new issue per release). Include release notes (markdown, typically the CHANGELOG entries for this version) in the same comment:
-
-   ```
-   @JuliaRegistrator register branch=release-X.Y.Z
+   ```markdown
+   @JuliaRegistrator register
 
    Release notes:
 
@@ -37,14 +38,14 @@ Before anything else, determine the right version number and confirm it with the
    - blah
    ```
 
-   Caveats learned the hard way: Registrator ignores PR comments entirely ("disabled", it replies); and from an issue comment only `branch=<name>` is accepted — there is no way to pin a SHA, which is why step 2 exists. Also, the bot matches the raw trigger text anywhere in a comment or PR/issue body, even inside backticks or code spans (a PR description merely *quoting* the phrase drew a reply from the bot) — never write the literal trigger phrase in comments on #124 or anywhere else unless you intend to register. Registrator resolves the branch to a concrete SHA when it processes the comment and replies with a link to the PR it opens in the General registry. The notes are added to that registry PR and to the GitHub release. (If the register comment was posted without notes, re-invoke Registrator with them to update the registration — see [Registrator's reply](https://github.com/cossio/RestrictedBoltzmannMachines.jl/commit/a4dcb8cee859c752881c6c1bb6051edaffcecf84#commitcomment-188488609).)
+   Use the CHANGELOG entries for this version as the release notes. A commit comment pins registration to that commit, so no release branch or registration issue is needed. Post through the GitHub commit page or the commit-comments API (`gh api repos/cossio/RestrictedBoltzmannMachines.jl/commits/<sha>/comments -f body="..."`). Registrator replies on the commit with a link to the General registry PR; the notes flow into that PR and the GitHub release.
 
-4. **Monitor the registry PR until it merges.** Registrator's reply to the triggering comment links it (e.g. [this reply](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/124#issuecomment-4966310598) → [JuliaRegistries/General#161274](https://github.com/JuliaRegistries/General/pull/161274) for v5.7.0). AutoMerge normally merges it within ~15–30 minutes. Watch for AutoMerge failures (version-increment, compat or project-file checks) and for comments from registry maintainers requesting changes. If changes are needed, restart the flow: commit the fixes to `master` (keeping Project.toml at `X.Y.Z`), delete the old `release-X.Y.Z` branch and recreate it at the new master commit, and comment `@JuliaRegistrator register branch=release-X.Y.Z` on issue #124 again — Registrator then updates the registration to point at the new commit. (If the GitHub tooling in the session cannot read the General repo directly, the registry PR page is public and can be read via web fetch.)
+3. **Monitor the registry PR until it merges.** AutoMerge normally merges it within ~15–30 minutes. Watch for AutoMerge failures (version-increment, compat, or project-file checks) and comments from registry maintainers. If changes are needed, commit the fixes to `master` while keeping Project.toml at `X.Y.Z`, then post a new Registrator comment on the corrected commit. Registrator updates the registration to that commit. If the GitHub tooling in the session cannot read the General repo directly, read the public registry PR page.
 
-5. **Tag and GitHub release.** Once the registry PR merges, TagBot creates the `vX.Y.Z` tag at the registered commit and the GitHub release (with the notes) automatically — no action needed. Afterwards the `release-X.Y.Z` branch is redundant (the tag protects the commit) and may be deleted.
+4. **Tag and GitHub release.** Once the registry PR merges, TagBot creates the `vX.Y.Z` tag at the registered commit and the GitHub release with the notes automatically — no action needed.
 
-6. **Start the next cycle.** Once the version is successfully registered in General (registry PR merged, tag created), always suggest that the user follow up with a new PR that bumps Project.toml to the next `-DEV` version and adds a fresh `## Unreleased` section to CHANGELOG.md, so development commits never accumulate under a released version number. (E.g. after releasing `5.7.0`, bump to `5.7.1-DEV`, or `5.8.0-DEV` if new features are anticipated — the choice is only a hint, since the actual release number is re-derived from the changes when releasing; see the semver section above.)
+5. **Start the next cycle.** Once the version is successfully registered in General (registry PR merged, tag created), always suggest that the user follow up with a new PR that bumps Project.toml to the next `-DEV` version and adds a fresh `## Unreleased` section to CHANGELOG.md, so development commits never accumulate under a released version number. (E.g. after releasing `5.7.0`, bump to `5.7.1-DEV`, or `5.8.0-DEV` if new features are anticipated — the choice is only a hint, since the actual release number is re-derived from the changes when releasing; see the semver section above.)
 
 A condensed human-facing copy of this procedure lives in `docs/src/developer/testing.md`; keep it in sync with this skill.
 
-Worked example: v5.7.0 — release PR [#123](https://github.com/cossio/RestrictedBoltzmannMachines.jl/pull/123), registration comment on [#124](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/124#issuecomment-4966308410).
+Worked example: [the v5.3.2 registration comment](https://github.com/cossio/RestrictedBoltzmannMachines.jl/commit/a4dcb8cee859c752881c6c1bb6051edaffcecf84#commitcomment-188488609).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,10 +134,14 @@ CUDA.jl, and HDF5 persistence. It requires Julia 1.10 or later.
 - During development, the version in `Project.toml` carries a `-DEV` suffix
   (for example, `5.4.0-DEV`), and changes accumulate under `## Unreleased` in
   `CHANGELOG.md`.
+- Choose release numbers using ColPrac's Julia package SemVer guidance. For this
+  post-1.0 package, breaking changes bump major, non-breaking features bump
+  minor, and bug fixes bump patch. Suggest one version with a brief explanation,
+  but always leave the final decision to the user and wait for explicit
+  confirmation before making release changes.
 - Use `$register-new-version` for release, registration, tagging, or publishing
   tasks. The shared workflow lives at
   `.claude/skills/register-new-version/SKILL.md` and is exposed to Codex at
   `.agents/skills/register-new-version/SKILL.md`. It covers the release commit,
-  frozen `release-X.Y.Z` registration branch, triggering Registrator from
-  [issue #124](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/124),
-  and monitoring the General registry PR.
+  triggering Registrator directly on that commit, and monitoring the General
+  registry PR.

--- a/docs/src/developer/testing.md
+++ b/docs/src/developer/testing.md
@@ -27,33 +27,34 @@ those locally only.
 
 During development the version in `Project.toml` carries a `-DEV` suffix
 (e.g. `5.4.0-DEV`), and changes accumulate under an `## Unreleased` section in
-`CHANGELOG.md`. To release:
+`CHANGELOG.md`. Choose the release number using
+[ColPrac's Julia package guidance](https://docs.sciml.ai/ColPrac/stable/#Guidance-on-Package-Releases):
+for this post-1.0 package, use a major bump for breaking changes, a minor bump
+for non-breaking features (including ordinary dependency or Julia compatibility
+changes), and a patch bump for bug fixes (including compatibility changes made
+solely to fix a bug). Treat documented unexported names as public API,
+corrections to clearly broken behavior as bug fixes, introducing deprecations
+as non-breaking, and removing deprecations as breaking. The release agent
+suggests one version with a brief explanation, but the user always makes the
+final decision. Do not change release files or begin registration until the
+user explicitly chooses the version. Then:
 
 1. Make a single commit titled `vX.Y.Z` that drops the `-DEV` suffix from
    `version` in `Project.toml` and renames the `## Unreleased` CHANGELOG
    section to `## X.Y.Z`. Land it on `master` (directly, or via a PR).
-2. Push a frozen branch `release-X.Y.Z` pointing at the master commit that
-   contains the release (the merge commit if it landed via PR):
-   `git push origin <sha>:refs/heads/release-X.Y.Z`. Never commit to this
-   branch — it pins the commit that gets registered even if `master` keeps
-   moving.
-3. Comment on the permanent (closed) registration issue
-   [#124](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/124):
-   `@JuliaRegistrator register branch=release-X.Y.Z`, including release notes
-   (markdown, typically the CHANGELOG entries for this version) in the same
-   comment. Registrator ignores PR comments, and issue comments accept only a
-   `branch=` target (no SHA), hence the pinned branch. The notes are added to
-   the registry PR and to the GitHub release that TagBot creates. Registrator
-   opens a PR in the General registry; once it merges, TagBot creates the
-   `vX.Y.Z` tag at the registered commit and the GitHub release automatically.
-4. Monitor the registration PR in General (linked in Registrator's reply to
-   the triggering comment) until it merges — AutoMerge usually takes
+2. Push the release commit, open that exact commit on GitHub (the merge commit
+   if the release landed via PR), and comment `@JuliaRegistrator register`
+   directly on it. Include a `Release notes:` section containing the CHANGELOG
+   entries for this version in the same comment. The commit comment pins the
+   registered SHA, so no release branch is needed. Registrator replies on the
+   commit with the General registry PR.
+3. Monitor the registration PR until it merges — AutoMerge usually takes
    ~15–30 minutes. If AutoMerge fails or a registry maintainer requests
-   changes, restart the flow: commit the fixes to `master` (keeping
-   `Project.toml` at `X.Y.Z`), delete and recreate `release-X.Y.Z` at the new
-   master commit, and comment on issue #124 again to re-trigger the
-   registration pointing at the new branch. Once the registry PR has merged
-   and TagBot has tagged, the `release-X.Y.Z` branch may be deleted.
+   changes, commit the fixes to `master` while keeping `Project.toml` at
+   `X.Y.Z`, then post a new Registrator comment on the corrected commit.
+4. Once the registry PR merges, TagBot creates the `vX.Y.Z` tag at the
+   registered commit and the GitHub release with the supplied notes
+   automatically.
 5. Right after the release (registry PR merged, tag created), follow up with
    a new PR that bumps `Project.toml` to the next `-DEV` version (e.g.
    `5.7.1-DEV` after releasing `5.7.0`, or `5.8.0-DEV` if new features are


### PR DESCRIPTION
## Summary

- trigger Registrator by commenting directly on the exact release commit
- remove the frozen release branch and permanent registration issue workarounds
- use ColPrac's Julia SemVer guidance to suggest a version with a brief explanation while leaving the final decision to the user
- keep the release skill, developer documentation, and repository instructions in sync

## Why

The frozen branch and issue-based registration flow existed to accommodate cloud environments that could not comment on commits. Releases now run from a local environment that can use GitHub commit comments, which pin registration to the intended SHA without the extra branch lifecycle.

The version-selection guidance also now matches the project's ColPrac interpretation and explicitly requires user confirmation before any release changes or registration actions.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache-release-skill uv run --with pyyaml /home/jfdcd/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/register-new-version`
- `UV_CACHE_DIR=/tmp/uv-cache-release-skill uv run --with pyyaml .github/scripts/lint_agent_docs.py`
- `git diff --check`
- stale workaround reference scan across the release skill and synchronized documentation