### PR TITLE
Drop stale ucd! references after the UCD extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,11 @@ All notable changes to this project will be documented in this file. The format 
   add `ucdRBMs` and replace `using RestrictedBoltzmannMachines: ucd!` with
   `using ucdRBMs: ucd!`. Behavior is unchanged.
 
-- **Breaking**: the trainers `pcd!` (plain, centered, and standardized) and
-  `ucd!` now all invoke their `callback` with the same keywords,
-  `(; rbm, optim, state, ps, iter, vd, wd, ∂)`, plus `vm` for the PCD trainers
-  and `meeting_steps`/`discarded` for `ucd!`. Previously each trainer passed a
-  different subset. Callbacks that spell out the exact keyword list must be
-  updated; more robustly, slurp unused keywords with a trailing `_...`
+- **Breaking**: the `pcd!` trainers (plain, centered, and standardized) now all
+  invoke their `callback` with the same keywords,
+  `(; rbm, optim, state, ps, iter, vd, wd, ∂, vm)`. Previously each trainer
+  passed a different subset. Callbacks that spell out the exact keyword list
+  must be updated; more robustly, slurp unused keywords with a trailing `_...`
   ([#170](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/170)).
 - `pcd!(::CenteredRBM)` now accepts the `shuffle`, `ps`, and `state` keywords,
   like the other trainers. Defaults preserve the previous behavior (minibatches

--- a/src/train/train.jl
+++ b/src/train/train.jl
@@ -1,4 +1,4 @@
-#= Shared training loop for `pcd!` and `ucd!`.
+#= Shared training loop for the `pcd!` trainers (plain, centered, and standardized).
 
 The public trainers share the same skeleton: validate, prepare the data, set up the
 optimizer, then repeatedly draw a minibatch, estimate the positive/negative phase
@@ -9,8 +9,8 @@ wrapper supplies as closures.
 
 Every trainer invokes its callback with the same keywords,
 `(; rbm, optim, state, ps, iter, vd, wd, ∂)`, plus the extras returned by its
-negative phase (`vm` for the PCD trainers; `meeting_steps` and `discarded` for
-`ucd!`). Callbacks should slurp unused keywords with a trailing `_...`.
+negative phase (`vm` for the PCD trainers). Callbacks should slurp unused keywords
+with a trailing `_...`.
 
 Gauge constraints are reset as `zerosum!` first, then rescaling: rescaling multiplies
 the weights attached to each hidden unit by a scalar (or, for `StandardizedRBM`,


### PR DESCRIPTION
Small follow-up to #179. Two mentions of `ucd!` lingered in this package after UCD moved to [ucdRBMs.jl](https://github.com/cossio/ucdRBMs.jl):

- The `_train!` header comment in `src/train/train.jl` opened with "Shared training loop for `pcd!` and `ucd!`" and described ucd's `meeting_steps`/`discarded` callback extras. `_train!` now serves only the three `pcd!` methods, so the comment is scoped to them.
- The 6.0 `CHANGELOG.md` bullet for the unified callback keywords listed `ucd!` and its `meeting_steps`/`discarded` extras. Since 6.0 no longer ships `ucd!`, the bullet now describes only the `pcd!` trainers and their `vm` extra.

No code changes — comment and changelog only. This resolves the editorial question I raised on #179 about the residual `ucd!` reference in the release notes; if you'd rather the changelog keep the fuller history (noting ucd! moved), say so and I'll adjust the wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sHejbM9ieMFGvhAqh82KU