### PR TITLE
Remove stale notebooks path from review guidance

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -60,8 +60,7 @@ found is a Nit, lead the summary with "No blocking issues."
 - Anything CI already enforces: the test suite (`ci.yml`) and the
   agent-docs linter (`.github/scripts/lint_agent_docs.py`).
 - Formatting and code style preferences.
-- Generated files: `Manifest.toml`, built documentation output, and
-  anything under `notebooks/`.
+- Generated files: `Manifest.toml` and built documentation output.
 - Missing CHANGELOG.md entries for CI, workflow, or repo-tooling changes —
   the changelog records only user-facing package changes.
 


### PR DESCRIPTION
## Summary

- remove the obsolete `notebooks/` path from the generated-files guidance in `REVIEW.md`
- retain the exclusions for `Manifest.toml` and built documentation output

## Root cause

The agent-docs linter validates backticked repository paths. `REVIEW.md` still referenced `notebooks/` after that directory was removed, causing [the Agent docs job](https://github.com/cossio/RestrictedBoltzmannMachines.jl/actions/runs/30095350692/job/89487984512) to fail.

## Validation

- `uv run --no-cache .github/scripts/lint_agent_docs.py` — 0 errors, 0 warnings
- `git diff --check`