### PR TITLE
v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.0.0
 
 - **Breaking**: the minimum supported Julia version is now 1.11 (was 1.10). This
   enables `public` declarations that mark the supported API explicitly.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "6.0.0-DEV"
+version = "6.0.0"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Release commit for **v6.0.0**: drops the `-DEV` suffix in `Project.toml` and renames the `## Unreleased` CHANGELOG section to `## 6.0.0`. No code changes.

This is a **major** release (from v5.8.2) — ColPrac requires a major bump for the accumulated breaking changes:
- Minimum Julia raised to 1.11.
- Unbiased Contrastive Divergence moved out to [ucdRBMs.jl](https://github.com/cossio/ucdRBMs.jl).
- Unified `pcd!` callback keywords.
- Removed unused internal helpers documented via `@autodocs`.
- Dropped `DiffRules`; raised dependency lower bounds.
- Declared an explicit `public` API surface.

Full notes are the `## 6.0.0` section of `CHANGELOG.md`.

**To release:** merge this PR, then I'll trigger `@JuliaRegistrator` on the merge commit and monitor the General registry PR through AutoMerge. (I can't push to or merge `master` myself.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sHejbM9ieMFGvhAqh82KU