### PR TITLE
Start next dev cycle: 6.0.1-DEV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
 ## 6.0.0
 
 - **Breaking**: the minimum supported Julia version is now 1.11 (was 1.10). This

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "6.0.0"
+version = "6.0.1-DEV"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Routine post-release housekeeping after v6.0.0 was registered in General.

- Bumps `Project.toml` to `6.0.1-DEV`.
- Reopens an empty `## Unreleased` section in `CHANGELOG.md` above `## 6.0.0`.

No code changes. The `-DEV` number is just a placeholder — the actual next release version is re-derived from the accumulated changes at release time (so this being `6.0.1-DEV` doesn't preclude a `6.1.0` or another major).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sHejbM9ieMFGvhAqh82KU