### PR TITLE
Adaptive and dynamic temperature schedules for AIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
-- Added `adaptive_betas`, which adaptively selects an inverse temperature
-  schedule for annealed importance sampling by keeping the effective sample size
-  of the incremental importance weights above a target fraction on a pilot
-  population. The resulting schedule can be passed as `βs` to `ais`, `aise`, and
-  `raise`.
+- Added dynamic temperature adaptation for annealed importance sampling: `ais`,
+  `aise`, and `raise` accept a new `target` keyword (mutually exclusive with
+  `nbetas`) that selects each next inverse temperature on the fly, keeping the
+  effective sample size of the incremental importance weights above `target`.
+  In this mode they return `(; F, βs)` with the realized schedule. The
+  underlying routine is `ais_dynamic`.
+- Added `adaptive_betas`, which computes such an adapted temperature schedule on
+  an independent pilot population (yielding strictly unbiased subsequent runs).
+  The resulting schedule can be passed as `βs` to `ais`, `aise`, and `raise`.
 - `ais`, `aise`, and `raise` accept a new `steps` keyword controlling the number
   of Gibbs sweeps performed at each intermediate temperature (default 1, the
   previous behavior).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file. The format 
   `nbetas`) that selects each next inverse temperature on the fly, keeping the
   effective sample size of the incremental importance weights above `target`.
   In this mode they return `(; F, βs)` with the realized schedule. The
-  underlying routine is `ais_dynamic`.
+  underlying routine is `adaptive_ais`.
 - Added `adaptive_betas`, which computes such an adapted temperature schedule on
   an independent pilot population (yielding strictly unbiased subsequent runs).
   The resulting schedule can be passed as `βs` to `ais`, `aise`, and `raise`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Added `adaptive_betas`, which adaptively selects an inverse temperature
+  schedule for annealed importance sampling by keeping the effective sample size
+  of the incremental importance weights above a target fraction on a pilot
+  population. The resulting schedule can be passed as `βs` to `ais`, `aise`, and
+  `raise`.
+- `ais`, `aise`, and `raise` accept a new `steps` keyword controlling the number
+  of Gibbs sweeps performed at each intermediate temperature (default 1, the
+  previous behavior).
+- `raise` now interprets a supplied `βs` schedule in the same convention as
+  `aise` (inverse temperatures of the target model, sorted from 0 to 1),
+  traversing it in reverse internally. Uniform schedules such as the default
+  `range(0, 1, nbetas)` are unaffected; asymmetric schedules (e.g. from
+  `adaptive_betas`) can now be shared between `aise` and `raise`.
+
 ## 6.0.0
 
 - **Breaking**: the minimum supported Julia version is now 1.11 (was 1.10). This

--- a/docs/src/literate/ais.jl
+++ b/docs/src/literate/ais.jl
@@ -21,7 +21,7 @@ import RestrictedBoltzmannMachines as RBMs
 using Statistics: mean, std, middle
 using ValueHistories: MVHistory
 using RestrictedBoltzmannMachines: Binary, BinaryRBM, initialize!, pcd!,
-    aise, raise, logmeanexp, logstdexp, sample_v_from_v
+    aise, raise, adaptive_betas, logmeanexp, logstdexp, sample_v_from_v
 
 # ## Training
 
@@ -111,3 +111,27 @@ Makie.xlims!(extrema(ndists)...)
 Makie.axislegend(ax, position = :rb)
 Makie.resize_to_layout!(fig)
 fig
+
+#=
+## Adaptive temperature schedule
+
+Instead of a uniform grid of inverse temperatures, `adaptive_betas` selects the schedule
+adaptively: a pilot population of chains is annealed from the reference distribution to
+the model, and each temperature step is chosen (by bisection) as the largest step whose
+incremental importance weights retain a target effective sample size. This concentrates
+temperatures where the annealing path is hard and spends none where it is easy, often
+matching the accuracy of a much longer uniform schedule.
+=#
+
+βs = @time adaptive_betas(rbm; init, nsamples = 100, target = 0.999)
+length(βs)
+
+# Run forward and reverse AIS re-using the adapted schedule.
+
+R_ada_f = @time aise(rbm, βs; nsamples, init)
+R_ada_r = @time raise(rbm, βs; init, v = v[:, :, rand(1:size(v, 3), nsamples)])
+nothing #hide
+
+# The sandwich obtained from the adapted schedule:
+
+logmeanexp(R_ada_f), -logmeanexp(-R_ada_r)

--- a/docs/src/literate/ais.jl
+++ b/docs/src/literate/ais.jl
@@ -113,14 +113,32 @@ Makie.resize_to_layout!(fig)
 fig
 
 #=
-## Adaptive temperature schedule
+## Adaptive temperature schedules
 
-Instead of a uniform grid of inverse temperatures, `adaptive_betas` selects the schedule
-adaptively: a pilot population of chains is annealed from the reference distribution to
-the model, and each temperature step is chosen (by bisection) as the largest step whose
+Instead of a uniform grid of inverse temperatures, the schedule can be adapted to the
+annealing path: each temperature step is chosen (by bisection) as the largest step whose
 incremental importance weights retain a target effective sample size. This concentrates
 temperatures where the annealing path is hard and spends none where it is easy, often
 matching the accuracy of a much longer uniform schedule.
+
+Passing the `target` keyword to `aise` or `raise` adapts the temperatures dynamically
+during the run itself. In this mode the estimators return `(; F, βs)`, with the realized
+schedule alongside the estimates.
+=#
+
+R_dyn_f = @time aise(rbm; target = 0.999, nsamples, init)
+R_dyn_r = @time raise(rbm; target = 0.999, init, v = v[:, :, rand(1:size(v, 3), nsamples)])
+length(R_dyn_f.βs), length(R_dyn_r.βs)
+
+# The sandwich obtained from the dynamically adapted runs:
+
+logmeanexp(R_dyn_f.F), -logmeanexp(-R_dyn_r.F)
+
+#=
+Dynamic adaptation uses the same chains for the schedule and the estimate, which
+introduces a small bias that vanishes with the number of chains. Alternatively,
+`adaptive_betas` computes the schedule on an independent pilot population, and the
+resulting fixed schedule can be re-used in strictly unbiased `aise`/`raise` runs.
 =#
 
 βs = @time adaptive_betas(rbm; init, nsamples = 100, target = 0.999)

--- a/src/ais.jl
+++ b/src/ais.jl
@@ -23,16 +23,17 @@ For a variant or RAISE: https://arxiv.org/abs/1511.02543
 =#
 
 """
-    ais(rbm0, rbm1, v0, βs)
+    ais(rbm0, rbm1, v0, βs; steps=1)
 
 Provided `v0` is an equilibrated sample from `rbm0`, returns `F` such that `mean(exp.(F))` is
 an unbiased estimator of `Z1/Z0`, the ratio of partition functions of `rbm1` and `rbm0`.
+`steps` is the number of Gibbs sweeps performed at each intermediate temperature.
 
 !!! tip Use [`logmeanexp`](@ref)
     `logmeanexp(F)`, using the function `logmeanexp`[@ref] provided in this package,
     tends to give a better approximation of `log(Z1) - log(Z0)` than `mean(F)`.
 """
-function ais(rbm0::RBM, rbm1::RBM, v::AbstractArray, βs::AbstractVector)
+function ais(rbm0::RBM, rbm1::RBM, v::AbstractArray, βs::AbstractVector; steps::Int = 1)
     @assert issorted(βs) && 0 == first(βs) ≤ last(βs) == 1
     F = free_energy(rbm0, v)
     for β in βs
@@ -41,7 +42,7 @@ function ais(rbm0::RBM, rbm1::RBM, v::AbstractArray, βs::AbstractVector)
         else
             rbm = anneal(rbm0, rbm1; β)
             F -= free_energy(rbm, v)
-            v = sample_v_from_v(rbm, v)
+            v = sample_v_from_v(rbm, v; steps)
             F += free_energy(rbm, v)
         end
     end
@@ -49,13 +50,13 @@ function ais(rbm0::RBM, rbm1::RBM, v::AbstractArray, βs::AbstractVector)
     return F
 end
 
-function ais(rbm0::RBM, rbm1::RBM, v0::AbstractArray; nbetas::Int = 2)
+function ais(rbm0::RBM, rbm1::RBM, v0::AbstractArray; nbetas::Int = 2, steps::Int = 1)
     βs = range(0, 1, nbetas)
-    return ais(rbm0, rbm1, v0, βs)
+    return ais(rbm0, rbm1, v0, βs; steps)
 end
 
 """
-    aise(rbm, [βs]; [nbetas], init=rbm.visible, nsamples=1)
+    aise(rbm, [βs]; [nbetas], init=rbm.visible, nsamples=1, steps=1)
 
 AIS estimator of the log-partition function of `rbm`. It is recommended to fit `init` to
 the single-site statistics of `rbm` (or the data).
@@ -63,20 +64,29 @@ the single-site statistics of `rbm` (or the data).
 !!! tip Use large `nbetas`
     For more accurate estimates, use larger `nbetas`. It is usually better to have
     large `nbetas` and small `nsamples`, rather than large `nsamples` and small `nbetas`.
+
+!!! tip Adaptive schedules
+    Instead of the default uniform grid of `nbetas` temperatures, an adapted schedule
+    computed by [`adaptive_betas`](@ref) can be passed as `βs`.
 """
-function aise(rbm::RBM, βs::AbstractVector{<:Real}; init::AbstractLayer = rbm.visible, nsamples::Int = 1)
+function aise(rbm::RBM, βs::AbstractVector{<:Real}; init::AbstractLayer = rbm.visible, nsamples::Int = 1, steps::Int = 1)
     rbm0 = anneal_zero(init, rbm)
     v0 = sample_from_inputs(init, Falses(size(init)..., nsamples))
-    F = ais(rbm0, rbm, v0, βs)
+    F = ais(rbm0, rbm, v0, βs; steps)
     return F .+ log_partition_zero_weight(rbm0)
 end
 
 """
-    raise(rbm::RBM, βs; v, init)
+    raise(rbm::RBM, [βs]; [nbetas], v, init=rbm.visible, steps=1)
 
 Reverse AIS estimator of the log-partition function of `rbm`.
 While `aise` tends to understimate the log of the partition function, `raise` tends to
 overstimate it. `v` must be an equilibrated sample from `rbm`.
+
+`βs` follows the same convention as [`aise`](@ref): inverse temperatures of the target
+`rbm`, sorted from 0 to 1. The annealing path traverses it in reverse (from `rbm` down to
+the reference), so the same schedule (e.g. from [`adaptive_betas`](@ref)) can be shared
+between `aise` and `raise`.
 
 !!! tip Use [`logmeanexp`](@ref)
     If `F = raise(...)`, then `-logmeanexp(-F)`, using the function `logmeanexp`[@ref]
@@ -86,14 +96,106 @@ overstimate it. `v` must be an equilibrated sample from `rbm`.
     If `Rf = aise(...)`, `Rr = raise(...)` are the AIS and reverse AIS estimators, we have the
     stochastic bounds `logmeanexp(Rf) ≤ log(Z) ≤ -logmeanexp(-Rr)`.
 """
-function raise(rbm::RBM, βs::AbstractVector; v::AbstractArray, init::AbstractLayer = rbm.visible)
+function raise(rbm::RBM, βs::AbstractVector; v::AbstractArray, init::AbstractLayer = rbm.visible, steps::Int = 1)
     rbm0 = anneal_zero(init, rbm)
-    F = ais(rbm, rbm0, v, βs)
+    F = ais(rbm, rbm0, v, 1 .- reverse(βs); steps)
     return log_partition_zero_weight(rbm0) .- F
 end
 
 aise(rbm::RBM; nbetas::Int = 10000, kw...) = aise(rbm, range(0, 1, nbetas); kw...)
 raise(rbm::RBM; nbetas::Int = 10000, kw...) = raise(rbm, range(0, 1, nbetas); kw...)
+
+"""
+    adaptive_betas(rbm; init=rbm.visible, nsamples=100, target=0.99, max_betas=10_000, min_increment=1e-6, steps=1)
+    adaptive_betas(rbm0, rbm1, v0; target=0.99, max_betas=10_000, min_increment=1e-6, steps=1)
+
+Adaptively selects an inverse temperature schedule `βs` for annealed importance sampling,
+placing more intermediate temperatures where the annealing path from the reference model
+to the target model is hard, and fewer where it is easy.
+
+Starting from `β = 0`, a pilot population of Monte Carlo chains is annealed towards
+`β = 1`. Each next inverse temperature is chosen (by bisection) as the largest `β` whose
+incremental importance weights retain a normalized effective sample size of at least
+`target` over the pilot population. `min_increment` bounds the bisection tolerance and
+the smallest allowed temperature step, and `max_betas` caps the schedule length (a
+warning is emitted if the cap is reached).
+
+In the first form, the reference model and the pilot population are constructed from
+`init` as in [`aise`](@ref). In the second form, `v0` must be an equilibrated sample
+from `rbm0`, as in [`ais`](@ref).
+
+Returns a sorted vector of inverse temperatures, starting at 0 and ending at 1, which can
+be passed as `βs` to [`ais`](@ref), [`aise`](@ref), or [`raise`](@ref). Since the
+schedule is adapted on a fresh pilot population, the returned `βs` can be used in
+subsequent AIS runs without biasing them.
+"""
+function adaptive_betas(
+        rbm0::RBM, rbm1::RBM, v::AbstractArray;
+        target::Real = 0.99, max_betas::Int = 10_000, min_increment::Real = 1e-6, steps::Int = 1
+    )
+    @assert 0 < target < 1
+    @assert 0 < min_increment < 1
+    @assert max_betas ≥ 2
+    # need at least two chains to estimate the effective sample size
+    @assert length(v) ≥ 2 * length(rbm0.visible)
+    β = 0.0
+    βs = [β]
+    F = vec(free_energy(rbm0, v))
+    while β < 1 && length(βs) < max_betas
+        β = next_beta(rbm0, rbm1, v, F, β; target, min_increment)
+        push!(βs, β)
+        if β < 1
+            rbm = anneal(rbm0, rbm1; β)
+            v = sample_v_from_v(rbm, v; steps)
+            F = vec(free_energy(rbm, v))
+        end
+    end
+    if last(βs) < 1
+        @warn "adaptive_betas reached max_betas = $max_betas before β = 1; consider lowering `target` or raising `max_betas`"
+        push!(βs, 1.0)
+    end
+    return βs
+end
+
+function adaptive_betas(rbm::RBM; init::AbstractLayer = rbm.visible, nsamples::Int = 100, kw...)
+    rbm0 = anneal_zero(init, rbm)
+    v0 = sample_from_inputs(init, Falses(size(init)..., nsamples))
+    return adaptive_betas(rbm0, rbm, v0; kw...)
+end
+
+#=
+Largest β′ ∈ (β, 1] such that the normalized effective sample size of the incremental
+importance weights exp.(F - F_β′(v)) stays above `target`, found by bisection
+(the ESS is decreasing in β′, up to Monte Carlo noise).
+=#
+function next_beta(
+        rbm0::RBM, rbm1::RBM, v::AbstractArray, F::AbstractVector, β::Real;
+        target::Real, min_increment::Real
+    )
+    ess(β′) = incremental_ess(F, vec(free_energy(anneal(rbm0, rbm1; β = β′), v)))
+    if ess(1.0) ≥ target
+        return 1.0
+    end
+    lo, hi = β, 1.0
+    while hi - lo > min_increment
+        mid = (lo + hi) / 2
+        if ess(mid) ≥ target
+            lo = mid
+        else
+            hi = mid
+        end
+    end
+    return min(max(lo, β + min_increment), 1.0) # always make progress
+end
+
+#=
+Normalized effective sample size (ESS / number of chains) of the incremental importance
+weights exp.(F0 - F1), computed in a numerically stable way.
+=#
+function incremental_ess(F0::AbstractVector, F1::AbstractVector)
+    ℓ = F0 - F1
+    return exp(2logsumexp(ℓ) - logsumexp(2ℓ) - log(length(ℓ)))
+end
 
 """
     anneal(rbm0, rbm1; β)

--- a/src/ais.jl
+++ b/src/ais.jl
@@ -24,10 +24,18 @@ For a variant or RAISE: https://arxiv.org/abs/1511.02543
 
 """
     ais(rbm0, rbm1, v0, βs; steps=1)
+    ais(rbm0, rbm1, v0; nbetas=2, steps=1)
+    ais(rbm0, rbm1, v0; target, max_betas=10_000, min_increment=1e-6, steps=1)
 
 Provided `v0` is an equilibrated sample from `rbm0`, returns `F` such that `mean(exp.(F))` is
 an unbiased estimator of `Z1/Z0`, the ratio of partition functions of `rbm1` and `rbm0`.
 `steps` is the number of Gibbs sweeps performed at each intermediate temperature.
+
+The annealing schedule is either given explicitly as `βs`, or as a uniform grid of
+`nbetas` temperatures. Alternatively, passing the `target` keyword (mutually exclusive
+with `nbetas`) adapts the temperatures dynamically during the run itself, as in
+[`ais_dynamic`](@ref), which then returns the named tuple `(; F, βs)` with the realized
+schedule.
 
 !!! tip Use [`logmeanexp`](@ref)
     `logmeanexp(F)`, using the function `logmeanexp`[@ref] provided in this package,
@@ -50,24 +58,87 @@ function ais(rbm0::RBM, rbm1::RBM, v::AbstractArray, βs::AbstractVector; steps:
     return F
 end
 
-function ais(rbm0::RBM, rbm1::RBM, v0::AbstractArray; nbetas::Int = 2, steps::Int = 1)
-    βs = range(0, 1, nbetas)
-    return ais(rbm0, rbm1, v0, βs; steps)
+function ais(
+        rbm0::RBM, rbm1::RBM, v0::AbstractArray;
+        nbetas::Union{Int, Nothing} = nothing, target::Union{Real, Nothing} = nothing,
+        max_betas::Int = 10_000, min_increment::Real = 1.0e-6, steps::Int = 1
+    )
+    if isnothing(target)
+        βs = range(0, 1, something(nbetas, 2))
+        return ais(rbm0, rbm1, v0, βs; steps)
+    end
+    isnothing(nbetas) || throw(ArgumentError("`nbetas` and `target` are mutually exclusive"))
+    return ais_dynamic(rbm0, rbm1, v0; target, max_betas, min_increment, steps)
+end
+
+"""
+    ais_dynamic(rbm0, rbm1, v0; target, max_betas=10_000, min_increment=1e-6, steps=1)
+
+Annealed importance sampling from `rbm0` to `rbm1` (as in [`ais`](@ref)), adapting the
+inverse temperatures dynamically during the run: each next temperature is chosen (by
+bisection) as the largest step whose incremental importance weights retain a normalized
+effective sample size of at least `target` over the current chains. Requires at least
+two chains. Returns the named tuple `(; F, βs)`, where `F` are the importance sampling
+estimates as in [`ais`](@ref), and `βs` is the realized schedule.
+
+`min_increment` bounds the bisection tolerance and the smallest allowed temperature
+step. `max_betas` caps the schedule length: if the cap is reached, the annealing jumps
+directly to `β = 1` (with a warning).
+
+!!! note Adaptation bias
+    The temperatures are adapted on the same chains used for the estimate, which
+    introduces a small `O(1/nchains)` bias in `mean(exp.(F))` (vanishing as the number
+    of chains grows). For a strictly unbiased estimator, compute the schedule on an
+    independent pilot population with [`adaptive_betas`](@ref) and pass it to
+    [`ais`](@ref) as `βs`.
+"""
+function ais_dynamic(
+        rbm0::RBM, rbm1::RBM, v::AbstractArray;
+        target::Real, max_betas::Int = 10_000, min_increment::Real = 1.0e-6, steps::Int = 1
+    )
+    @assert 0 < target < 1
+    @assert 0 < min_increment < 1
+    @assert max_betas ≥ 2
+    if length(v) < 2 * length(rbm0.visible)
+        throw(ArgumentError("dynamic temperature adaptation requires at least 2 chains"))
+    end
+    β = 0.0
+    βs = [β]
+    Fcur = free_energy(rbm0, v) # free energies of the chains at the current temperature
+    F = zero(Fcur) # accumulated log importance weights
+    while β < 1
+        β = next_beta(rbm0, rbm1, v, vec(Fcur), β; target, min_increment)
+        if β < 1 && length(βs) == max_betas - 1
+            @warn "ais_dynamic reached max_betas = $max_betas before β = 1; consider lowering `target` or raising `max_betas`"
+            β = 1.0
+        end
+        push!(βs, β)
+        rbm = isone(β) ? rbm1 : anneal(rbm0, rbm1; β)
+        F += Fcur - free_energy(rbm, v)
+        if β < 1
+            v = sample_v_from_v(rbm, v; steps)
+            Fcur = free_energy(rbm, v)
+        end
+    end
+    return (; F, βs)
 end
 
 """
     aise(rbm, [βs]; [nbetas], init=rbm.visible, nsamples=1, steps=1)
+    aise(rbm; target, init=rbm.visible, nsamples, steps=1, max_betas=10_000, min_increment=1e-6)
 
 AIS estimator of the log-partition function of `rbm`. It is recommended to fit `init` to
 the single-site statistics of `rbm` (or the data).
 
+In the first form, the annealing schedule is a uniform grid of `nbetas` temperatures, or
+an explicitly given `βs` (e.g. from [`adaptive_betas`](@ref)). In the second form
+(`target` given, mutually exclusive with `nbetas`), the temperatures are adapted
+dynamically during the run, as in [`ais_dynamic`](@ref); this requires `nsamples ≥ 2`
+and returns the named tuple `(; F, βs)` with the realized schedule.
+
 !!! tip Use large `nbetas`
     For more accurate estimates, use larger `nbetas`. It is usually better to have
     large `nbetas` and small `nsamples`, rather than large `nsamples` and small `nbetas`.
-
-!!! tip Adaptive schedules
-    Instead of the default uniform grid of `nbetas` temperatures, an adapted schedule
-    computed by [`adaptive_betas`](@ref) can be passed as `βs`.
 """
 function aise(rbm::RBM, βs::AbstractVector{<:Real}; init::AbstractLayer = rbm.visible, nsamples::Int = 1, steps::Int = 1)
     rbm0 = anneal_zero(init, rbm)
@@ -78,6 +149,7 @@ end
 
 """
     raise(rbm::RBM, [βs]; [nbetas], v, init=rbm.visible, steps=1)
+    raise(rbm::RBM; target, v, init=rbm.visible, steps=1, max_betas=10_000, min_increment=1e-6)
 
 Reverse AIS estimator of the log-partition function of `rbm`.
 While `aise` tends to understimate the log of the partition function, `raise` tends to
@@ -87,6 +159,11 @@ overstimate it. `v` must be an equilibrated sample from `rbm`.
 `rbm`, sorted from 0 to 1. The annealing path traverses it in reverse (from `rbm` down to
 the reference), so the same schedule (e.g. from [`adaptive_betas`](@ref)) can be shared
 between `aise` and `raise`.
+
+If `target` is given (mutually exclusive with `nbetas`), the temperatures are adapted
+dynamically during the run, as in [`ais_dynamic`](@ref); this requires at least two
+chains in `v` and returns the named tuple `(; F, βs)`, where the realized schedule `βs`
+is reported in the ascending `aise` convention.
 
 !!! tip Use [`logmeanexp`](@ref)
     If `F = raise(...)`, then `-logmeanexp(-F)`, using the function `logmeanexp`[@ref]
@@ -102,8 +179,36 @@ function raise(rbm::RBM, βs::AbstractVector; v::AbstractArray, init::AbstractLa
     return log_partition_zero_weight(rbm0) .- F
 end
 
-aise(rbm::RBM; nbetas::Int = 10000, kw...) = aise(rbm, range(0, 1, nbetas); kw...)
-raise(rbm::RBM; nbetas::Int = 10000, kw...) = raise(rbm, range(0, 1, nbetas); kw...)
+function aise(
+        rbm::RBM;
+        nbetas::Union{Int, Nothing} = nothing, target::Union{Real, Nothing} = nothing,
+        init::AbstractLayer = rbm.visible, nsamples::Int = 1, steps::Int = 1,
+        max_betas::Int = 10_000, min_increment::Real = 1.0e-6
+    )
+    if isnothing(target)
+        return aise(rbm, range(0, 1, something(nbetas, 10_000)); init, nsamples, steps)
+    end
+    isnothing(nbetas) || throw(ArgumentError("`nbetas` and `target` are mutually exclusive"))
+    rbm0 = anneal_zero(init, rbm)
+    v0 = sample_from_inputs(init, Falses(size(init)..., nsamples))
+    F, βs = ais_dynamic(rbm0, rbm, v0; target, max_betas, min_increment, steps)
+    return (; F = F .+ log_partition_zero_weight(rbm0), βs)
+end
+
+function raise(
+        rbm::RBM;
+        nbetas::Union{Int, Nothing} = nothing, target::Union{Real, Nothing} = nothing,
+        v::AbstractArray, init::AbstractLayer = rbm.visible, steps::Int = 1,
+        max_betas::Int = 10_000, min_increment::Real = 1.0e-6
+    )
+    if isnothing(target)
+        return raise(rbm, range(0, 1, something(nbetas, 10_000)); v, init, steps)
+    end
+    isnothing(nbetas) || throw(ArgumentError("`nbetas` and `target` are mutually exclusive"))
+    rbm0 = anneal_zero(init, rbm)
+    F, γs = ais_dynamic(rbm, rbm0, v; target, max_betas, min_increment, steps)
+    return (; F = log_partition_zero_weight(rbm0) .- F, βs = 1 .- reverse(γs))
+end
 
 """
     adaptive_betas(rbm; init=rbm.visible, nsamples=100, target=0.99, max_betas=10_000, min_increment=1e-6, steps=1)
@@ -127,7 +232,9 @@ from `rbm0`, as in [`ais`](@ref).
 Returns a sorted vector of inverse temperatures, starting at 0 and ending at 1, which can
 be passed as `βs` to [`ais`](@ref), [`aise`](@ref), or [`raise`](@ref). Since the
 schedule is adapted on a fresh pilot population, the returned `βs` can be used in
-subsequent AIS runs without biasing them.
+subsequent AIS runs without biasing them. To instead adapt the temperatures dynamically
+within a single estimation run, see [`ais_dynamic`](@ref) (or the `target` keyword of
+[`aise`](@ref) and [`raise`](@ref)).
 """
 function adaptive_betas(
         rbm0::RBM, rbm1::RBM, v::AbstractArray;

--- a/src/ais.jl
+++ b/src/ais.jl
@@ -34,7 +34,7 @@ an unbiased estimator of `Z1/Z0`, the ratio of partition functions of `rbm1` and
 The annealing schedule is either given explicitly as `βs`, or as a uniform grid of
 `nbetas` temperatures. Alternatively, passing the `target` keyword (mutually exclusive
 with `nbetas`) adapts the temperatures dynamically during the run itself, as in
-[`ais_dynamic`](@ref), which then returns the named tuple `(; F, βs)` with the realized
+[`adaptive_ais`](@ref), which then returns the named tuple `(; F, βs)` with the realized
 schedule.
 
 !!! tip Use [`logmeanexp`](@ref)
@@ -68,11 +68,11 @@ function ais(
         return ais(rbm0, rbm1, v0, βs; steps)
     end
     isnothing(nbetas) || throw(ArgumentError("`nbetas` and `target` are mutually exclusive"))
-    return ais_dynamic(rbm0, rbm1, v0; target, max_betas, min_increment, steps)
+    return adaptive_ais(rbm0, rbm1, v0; target, max_betas, min_increment, steps)
 end
 
 """
-    ais_dynamic(rbm0, rbm1, v0; target, max_betas=10_000, min_increment=1e-6, steps=1)
+    adaptive_ais(rbm0, rbm1, v0; target, max_betas=10_000, min_increment=1e-6, steps=1)
 
 Annealed importance sampling from `rbm0` to `rbm1` (as in [`ais`](@ref)), adapting the
 inverse temperatures dynamically during the run: each next temperature is chosen (by
@@ -92,7 +92,7 @@ directly to `β = 1` (with a warning).
     independent pilot population with [`adaptive_betas`](@ref) and pass it to
     [`ais`](@ref) as `βs`.
 """
-function ais_dynamic(
+function adaptive_ais(
         rbm0::RBM, rbm1::RBM, v::AbstractArray;
         target::Real, max_betas::Int = 10_000, min_increment::Real = 1.0e-6, steps::Int = 1
     )
@@ -109,7 +109,7 @@ function ais_dynamic(
     while β < 1
         β = next_beta(rbm0, rbm1, v, vec(Fcur), β; target, min_increment)
         if β < 1 && length(βs) == max_betas - 1
-            @warn "ais_dynamic reached max_betas = $max_betas before β = 1; consider lowering `target` or raising `max_betas`"
+            @warn "adaptive_ais reached max_betas = $max_betas before β = 1; consider lowering `target` or raising `max_betas`"
             β = 1.0
         end
         push!(βs, β)
@@ -133,7 +133,7 @@ the single-site statistics of `rbm` (or the data).
 In the first form, the annealing schedule is a uniform grid of `nbetas` temperatures, or
 an explicitly given `βs` (e.g. from [`adaptive_betas`](@ref)). In the second form
 (`target` given, mutually exclusive with `nbetas`), the temperatures are adapted
-dynamically during the run, as in [`ais_dynamic`](@ref); this requires `nsamples ≥ 2`
+dynamically during the run, as in [`adaptive_ais`](@ref); this requires `nsamples ≥ 2`
 and returns the named tuple `(; F, βs)` with the realized schedule.
 
 !!! tip Use large `nbetas`
@@ -161,7 +161,7 @@ the reference), so the same schedule (e.g. from [`adaptive_betas`](@ref)) can be
 between `aise` and `raise`.
 
 If `target` is given (mutually exclusive with `nbetas`), the temperatures are adapted
-dynamically during the run, as in [`ais_dynamic`](@ref); this requires at least two
+dynamically during the run, as in [`adaptive_ais`](@ref); this requires at least two
 chains in `v` and returns the named tuple `(; F, βs)`, where the realized schedule `βs`
 is reported in the ascending `aise` convention.
 
@@ -191,7 +191,7 @@ function aise(
     isnothing(nbetas) || throw(ArgumentError("`nbetas` and `target` are mutually exclusive"))
     rbm0 = anneal_zero(init, rbm)
     v0 = sample_from_inputs(init, Falses(size(init)..., nsamples))
-    F, βs = ais_dynamic(rbm0, rbm, v0; target, max_betas, min_increment, steps)
+    F, βs = adaptive_ais(rbm0, rbm, v0; target, max_betas, min_increment, steps)
     return (; F = F .+ log_partition_zero_weight(rbm0), βs)
 end
 
@@ -206,7 +206,7 @@ function raise(
     end
     isnothing(nbetas) || throw(ArgumentError("`nbetas` and `target` are mutually exclusive"))
     rbm0 = anneal_zero(init, rbm)
-    F, γs = ais_dynamic(rbm, rbm0, v; target, max_betas, min_increment, steps)
+    F, γs = adaptive_ais(rbm, rbm0, v; target, max_betas, min_increment, steps)
     return (; F = log_partition_zero_weight(rbm0) .- F, βs = 1 .- reverse(γs))
 end
 
@@ -233,7 +233,7 @@ Returns a sorted vector of inverse temperatures, starting at 0 and ending at 1, 
 be passed as `βs` to [`ais`](@ref), [`aise`](@ref), or [`raise`](@ref). Since the
 schedule is adapted on a fresh pilot population, the returned `βs` can be used in
 subsequent AIS runs without biasing them. To instead adapt the temperatures dynamically
-within a single estimation run, see [`ais_dynamic`](@ref) (or the `target` keyword of
+within a single estimation run, see [`adaptive_ais`](@ref) (or the `target` keyword of
 [`aise`](@ref) and [`raise`](@ref)).
 """
 function adaptive_betas(

--- a/src/ais.jl
+++ b/src/ais.jl
@@ -117,8 +117,8 @@ Starting from `β = 0`, a pilot population of Monte Carlo chains is annealed tow
 `β = 1`. Each next inverse temperature is chosen (by bisection) as the largest `β` whose
 incremental importance weights retain a normalized effective sample size of at least
 `target` over the pilot population. `min_increment` bounds the bisection tolerance and
-the smallest allowed temperature step, and `max_betas` caps the schedule length (a
-warning is emitted if the cap is reached).
+the smallest allowed temperature step, and `max_betas` caps the schedule length (if the
+cap is reached, the last temperature is replaced by 1 and a warning is emitted).
 
 In the first form, the reference model and the pilot population are constructed from
 `init` as in [`aise`](@ref). In the second form, `v0` must be an equilibrated sample
@@ -152,7 +152,7 @@ function adaptive_betas(
     end
     if last(βs) < 1
         @warn "adaptive_betas reached max_betas = $max_betas before β = 1; consider lowering `target` or raising `max_betas`"
-        push!(βs, 1.0)
+        βs[end] = 1.0
     end
     return βs
 end

--- a/src/ais.jl
+++ b/src/ais.jl
@@ -286,13 +286,15 @@ function next_beta(
     lo, hi = β, 1.0
     while hi - lo > min_increment
         mid = (lo + hi) / 2
-        if ess(mid) ≥ target
+        if mid == lo || mid == hi # reached floating-point resolution
+            break
+        elseif ess(mid) ≥ target
             lo = mid
         else
             hi = mid
         end
     end
-    return min(max(lo, β + min_increment), 1.0) # always make progress
+    return min(max(lo, β + min_increment, nextfloat(float(β))), 1.0) # always make progress
 end
 
 #=

--- a/src/ais.jl
+++ b/src/ais.jl
@@ -131,7 +131,7 @@ subsequent AIS runs without biasing them.
 """
 function adaptive_betas(
         rbm0::RBM, rbm1::RBM, v::AbstractArray;
-        target::Real = 0.99, max_betas::Int = 10_000, min_increment::Real = 1e-6, steps::Int = 1
+        target::Real = 0.99, max_betas::Int = 10_000, min_increment::Real = 1.0e-6, steps::Int = 1
     )
     @assert 0 < target < 1
     @assert 0 < min_increment < 1

--- a/test/ais.jl
+++ b/test/ais.jl
@@ -1,11 +1,11 @@
-using Test: @test, @testset, @inferred
+using Test: @test, @testset, @inferred, @test_logs
 using Statistics: mean, std, var
 using Random: randn!, bitrand
 using LogExpFunctions: logsumexp
 using RestrictedBoltzmannMachines: RBM, BinaryRBM, Binary, Spin, Potts, Gaussian, ReLU, dReLU,
     xReLU, pReLU, nsReLU,
     energy, free_energy, sample_from_inputs, sample_v_from_v,
-    anneal, anneal_zero, ais, aise, raise, log_partition_zero_weight,
+    anneal, anneal_zero, ais, aise, raise, adaptive_betas, log_partition_zero_weight,
     logmeanexp, logvarexp, logstdexp, log_partition
 
 @testset "logmeanexp, logvarexp" begin
@@ -222,6 +222,58 @@ end
     v0 = sample_v_from_v(rbm0, randn(20, 10); steps = 1)
     R = ais(rbm0, rbm1, v0, nbetas = 10000)
     @test logmeanexp(R) ≈ lZ1 - lZ0 rtol = 0.1
+end
+
+@testset "ais steps" begin
+    rbm0 = BinaryRBM(randn(2), randn(1), zeros(2, 1))
+    rbm1 = BinaryRBM(randn(2), randn(1), randn(2, 1))
+    v0 = sample_v_from_v(rbm0, bitrand(2, 10000); steps = 1)
+    data = ais(rbm0, rbm1, v0; nbetas = 10, steps = 5)
+    @test logmeanexp(data) ≈ log_partition(rbm1) - log_partition(rbm0) rtol = 0.1
+    lZ = aise(rbm1; nbetas = 100, nsamples = 1000, steps = 3)
+    @test logmeanexp(lZ) ≈ log_partition(rbm1) rtol = 0.1
+end
+
+@testset "adaptive_betas" begin
+    rbm = BinaryRBM(randn(3), randn(2), randn(3, 2))
+    βs = adaptive_betas(rbm; nsamples = 100, target = 0.9)
+    @test first(βs) == 0
+    @test last(βs) == 1
+    @test issorted(βs)
+    @test allunique(βs)
+    @test all(0 .≤ βs .≤ 1)
+
+    lZ = aise(rbm, βs; nsamples = 10000)
+    @test logmeanexp(lZ) ≈ log_partition(rbm) rtol = 0.1
+
+    # raise accepts the same (asymmetric) schedule
+    v = sample_v_from_v(rbm, bitrand(3, 10000); steps = 500)
+    lZr = raise(rbm, βs; v)
+    @test -logmeanexp(-lZr) ≈ log_partition(rbm) rtol = 0.1
+
+    # harder annealing paths get more intermediate temperatures
+    weak = BinaryRBM(zeros(3), zeros(2), randn(3, 2) / 10)
+    strong = BinaryRBM(zeros(3), zeros(2), 5 .+ randn(3, 2))
+    @test length(adaptive_betas(weak)) < length(adaptive_betas(strong))
+
+    # max_betas caps the schedule length (with a warning), keeping valid endpoints
+    βs = @test_logs (:warn, r"max_betas") adaptive_betas(strong; max_betas = 5)
+    @test length(βs) == 6
+    @test first(βs) == 0
+    @test last(βs) == 1
+    @test issorted(βs)
+end
+
+@testset "adaptive_betas gaussian" begin
+    rbm = RBM(
+        Gaussian(; θ = randn(5), γ = 1 .+ 5rand(5)),
+        Gaussian(; θ = randn(3), γ = 1 .+ rand(3)),
+        randn(5, 3) / 10
+    )
+    βs = adaptive_betas(rbm; nsamples = 100, target = 0.9)
+    @test first(βs) == 0 && last(βs) == 1 && issorted(βs)
+    lZ = aise(rbm, βs; nsamples = 1000)
+    @test logmeanexp(lZ) ≈ log_partition(rbm) rtol = 0.1
 end
 
 @testset "zero hidden units" begin

--- a/test/ais.jl
+++ b/test/ais.jl
@@ -1,11 +1,11 @@
-using Test: @test, @testset, @inferred, @test_logs
+using Test: @test, @testset, @inferred, @test_logs, @test_throws
 using Statistics: mean, std, var
 using Random: randn!, bitrand
 using LogExpFunctions: logsumexp
 using RestrictedBoltzmannMachines: RBM, BinaryRBM, Binary, Spin, Potts, Gaussian, ReLU, dReLU,
     xReLU, pReLU, nsReLU,
     energy, free_energy, sample_from_inputs, sample_v_from_v,
-    anneal, anneal_zero, ais, aise, raise, adaptive_betas, log_partition_zero_weight,
+    anneal, anneal_zero, ais, aise, raise, ais_dynamic, adaptive_betas, log_partition_zero_weight,
     logmeanexp, logvarexp, logstdexp, log_partition
 
 @testset "logmeanexp, logvarexp" begin
@@ -263,6 +263,47 @@ end
     @test last(βs) == 1
     @test issorted(βs)
     @test allunique(βs)
+end
+
+@testset "ais_dynamic" begin
+    rbm0 = BinaryRBM(randn(2), randn(1), zeros(2, 1))
+    rbm1 = BinaryRBM(randn(2), randn(1), randn(2, 1))
+    v0 = sample_v_from_v(rbm0, bitrand(2, 10000); steps = 1)
+    F, βs = ais_dynamic(rbm0, rbm1, v0; target = 0.9)
+    @test length(F) == 10000
+    @test first(βs) == 0 && last(βs) == 1 && issorted(βs) && allunique(βs)
+    @test logmeanexp(F) ≈ log_partition(rbm1) - log_partition(rbm0) rtol = 0.1
+
+    # keyword dispatch through ais
+    R = ais(rbm0, rbm1, v0; target = 0.9)
+    @test logmeanexp(R.F) ≈ log_partition(rbm1) - log_partition(rbm0) rtol = 0.1
+    @test_throws ArgumentError ais(rbm0, rbm1, v0; nbetas = 10, target = 0.9)
+    @test_throws ArgumentError ais_dynamic(rbm0, rbm1, bitrand(2); target = 0.9)
+
+    # max_betas forces the jump to β = 1 (with a warning), keeping the length capped
+    strong = BinaryRBM(zeros(2), zeros(1), fill(10.0, 2, 1))
+    R = @test_logs (:warn, r"max_betas") match_mode = :any ais_dynamic(rbm0, strong, v0; target = 0.999, max_betas = 3)
+    @test length(R.βs) == 3
+    @test first(R.βs) == 0 && last(R.βs) == 1 && issorted(R.βs)
+end
+
+@testset "aise/raise dynamic" begin
+    rbm = BinaryRBM(randn(3), randn(2), randn(3, 2))
+    lZ = log_partition(rbm)
+    R = aise(rbm; target = 0.9, nsamples = 10000)
+    @test length(R.F) == 10000
+    @test first(R.βs) == 0 && last(R.βs) == 1 && issorted(R.βs)
+    @test logmeanexp(R.F) ≈ lZ rtol = 0.1
+
+    v = sample_v_from_v(rbm, bitrand(3, 10000); steps = 500)
+    Rr = raise(rbm; target = 0.9, v)
+    @test length(Rr.F) == 10000
+    @test first(Rr.βs) == 0 && last(Rr.βs) == 1 && issorted(Rr.βs)
+    @test -logmeanexp(-Rr.F) ≈ lZ rtol = 0.1
+
+    @test_throws ArgumentError aise(rbm; nbetas = 10, target = 0.9)
+    @test_throws ArgumentError aise(rbm; target = 0.9, nsamples = 1)
+    @test_throws ArgumentError raise(rbm; nbetas = 10, target = 0.9, v)
 end
 
 @testset "adaptive_betas gaussian" begin

--- a/test/ais.jl
+++ b/test/ais.jl
@@ -258,10 +258,11 @@ end
 
     # max_betas caps the schedule length (with a warning), keeping valid endpoints
     βs = @test_logs (:warn, r"max_betas") adaptive_betas(strong; max_betas = 5)
-    @test length(βs) == 6
+    @test length(βs) == 5
     @test first(βs) == 0
     @test last(βs) == 1
     @test issorted(βs)
+    @test allunique(βs)
 end
 
 @testset "adaptive_betas gaussian" begin

--- a/test/ais.jl
+++ b/test/ais.jl
@@ -5,7 +5,7 @@ using LogExpFunctions: logsumexp
 using RestrictedBoltzmannMachines: RBM, BinaryRBM, Binary, Spin, Potts, Gaussian, ReLU, dReLU,
     xReLU, pReLU, nsReLU,
     energy, free_energy, sample_from_inputs, sample_v_from_v,
-    anneal, anneal_zero, ais, aise, raise, ais_dynamic, adaptive_betas, log_partition_zero_weight,
+    anneal, anneal_zero, ais, aise, raise, adaptive_ais, adaptive_betas, log_partition_zero_weight,
     logmeanexp, logvarexp, logstdexp, log_partition
 
 @testset "logmeanexp, logvarexp" begin
@@ -265,11 +265,11 @@ end
     @test allunique(βs)
 end
 
-@testset "ais_dynamic" begin
+@testset "adaptive_ais" begin
     rbm0 = BinaryRBM(randn(2), randn(1), zeros(2, 1))
     rbm1 = BinaryRBM(randn(2), randn(1), randn(2, 1))
     v0 = sample_v_from_v(rbm0, bitrand(2, 10000); steps = 1)
-    F, βs = ais_dynamic(rbm0, rbm1, v0; target = 0.9)
+    F, βs = adaptive_ais(rbm0, rbm1, v0; target = 0.9)
     @test length(F) == 10000
     @test first(βs) == 0 && last(βs) == 1 && issorted(βs) && allunique(βs)
     @test logmeanexp(F) ≈ log_partition(rbm1) - log_partition(rbm0) rtol = 0.1
@@ -278,11 +278,11 @@ end
     R = ais(rbm0, rbm1, v0; target = 0.9)
     @test logmeanexp(R.F) ≈ log_partition(rbm1) - log_partition(rbm0) rtol = 0.1
     @test_throws ArgumentError ais(rbm0, rbm1, v0; nbetas = 10, target = 0.9)
-    @test_throws ArgumentError ais_dynamic(rbm0, rbm1, bitrand(2); target = 0.9)
+    @test_throws ArgumentError adaptive_ais(rbm0, rbm1, bitrand(2); target = 0.9)
 
     # max_betas forces the jump to β = 1 (with a warning), keeping the length capped
     strong = BinaryRBM(zeros(2), zeros(1), fill(10.0, 2, 1))
-    R = @test_logs (:warn, r"max_betas") match_mode = :any ais_dynamic(rbm0, strong, v0; target = 0.999, max_betas = 3)
+    R = @test_logs (:warn, r"max_betas") match_mode = :any adaptive_ais(rbm0, strong, v0; target = 0.999, max_betas = 3)
     @test length(R.βs) == 3
     @test first(R.βs) == 0 && last(R.βs) == 1 && issorted(R.βs)
 end

--- a/test/ais.jl
+++ b/test/ais.jl
@@ -306,6 +306,15 @@ end
     @test_throws ArgumentError raise(rbm; nbetas = 10, target = 0.9, v)
 end
 
+@testset "tiny min_increment terminates" begin
+    # min_increment below floating-point resolution must not hang the bisection
+    rbm = BinaryRBM(randn(3), randn(2), randn(3, 2))
+    βs = adaptive_betas(rbm; nsamples = 10, target = 0.5, min_increment = 1.0e-20)
+    @test first(βs) == 0 && last(βs) == 1 && issorted(βs)
+    R = aise(rbm; target = 0.5, nsamples = 10, min_increment = 1.0e-20)
+    @test first(R.βs) == 0 && last(R.βs) == 1 && issorted(R.βs)
+end
+
 @testset "adaptive_betas gaussian" begin
     rbm = RBM(
         Gaussian(; θ = randn(5), γ = 1 .+ 5rand(5)),

--- a/test/ais.jl
+++ b/test/ais.jl
@@ -307,11 +307,13 @@ end
 end
 
 @testset "tiny min_increment terminates" begin
-    # min_increment below floating-point resolution must not hang the bisection
-    rbm = BinaryRBM(randn(3), randn(2), randn(3, 2))
-    βs = adaptive_betas(rbm; nsamples = 10, target = 0.5, min_increment = 1.0e-20)
+    # min_increment below floating-point resolution must not hang the bisection.
+    # Strong couplings guarantee the full jump fails the ESS criterion, so the
+    # bisection runs down to floating-point resolution.
+    rbm = BinaryRBM(zeros(3), zeros(2), fill(2.0, 3, 2))
+    βs = adaptive_betas(rbm; nsamples = 10, target = 0.9, min_increment = 1.0e-20)
     @test first(βs) == 0 && last(βs) == 1 && issorted(βs)
-    R = aise(rbm; target = 0.5, nsamples = 10, min_increment = 1.0e-20)
+    R = aise(rbm; target = 0.9, nsamples = 10, min_increment = 1.0e-20)
     @test first(R.βs) == 0 && last(R.βs) == 1 && issorted(R.βs)
 end
 

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -424,4 +424,8 @@ end
     @test first(βs) == 0 && last(βs) == 1 && issorted(βs)
     R = aise(jl_rbm, βs; nsamples = 4)
     @test all(isfinite, adapt(Array, R))
+
+    R = aise(jl_rbm; target = 0.5, nsamples = 4)
+    @test first(R.βs) == 0 && last(R.βs) == 1 && issorted(R.βs)
+    @test all(isfinite, adapt(Array, R.F))
 end

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -17,7 +17,8 @@ using RestrictedBoltzmannMachines: RBM, CenteredRBM, StandardizedRBM, ∂RBM, Bi
     inputs_h_from_v, inputs_v_from_h, mean_h_from_v, mean_v_from_h,
     sample_h_from_v, sample_v_from_h, sample_v_from_v, reconstruction_error,
     log_pseudolikelihood, log_pseudolikelihood_stoch,
-    initialize!, pcd!, ∂free_energy, zerosum!, rescale_weights!, weight_norms, aise, raise
+    initialize!, pcd!, ∂free_energy, zerosum!, rescale_weights!, weight_norms, aise, raise,
+    adaptive_betas
 
 JLArrays.allowscalar(false)
 
@@ -417,5 +418,10 @@ end
     @test all(isfinite, adapt(Array, R))
     jl_v = JLArray(float(bitrand(N..., 4)))
     R = raise(jl_rbm; nbetas = 20, v = jl_v)
+    @test all(isfinite, adapt(Array, R))
+
+    βs = adaptive_betas(jl_rbm; nsamples = 4, target = 0.5)
+    @test first(βs) == 0 && last(βs) == 1 && issorted(βs)
+    R = aise(jl_rbm, βs; nsamples = 4)
     @test all(isfinite, adapt(Array, R))
 end


### PR DESCRIPTION
## Summary

Improves the robustness of the AIS log-partition / log-likelihood estimator, and adds two forms of adaptive temperature scheduling.

- **Dynamic adaptation (`ais_dynamic`, and the `target` keyword of `ais`/`aise`/`raise`)**: the temperatures are adapted on the fly *during* the estimation run itself — each next inverse temperature is chosen by bisection as the largest step whose incremental importance weights retain a normalized effective sample size of at least `target` over the current chains, in the spirit of adaptive tempering in SMC (Del Moral et al. 2012; Zhou, Johansen & Aston 2016). No pilot run needed; requires ≥ 2 chains; returns `(; F, βs)` with the realized schedule. `target` is mutually exclusive with `nbetas`. Adapting on the same chains introduces a small O(1/nchains) bias (noted in the docstrings), which is where the second variant comes in:
- **`adaptive_betas`** (pilot-based): computes the same ESS-controlled schedule on an independent pilot population; the returned fixed `βs` can then be passed to `aise`/`raise` for strictly unbiased runs. Guarded by `min_increment` (bisection tolerance / minimum step) and `max_betas` (cap with warning, schedule length never exceeds the cap).
- **`steps` keyword** on `ais`/`aise`/`raise`: number of Gibbs sweeps per intermediate temperature (default 1, previous behavior).
- **`raise` schedule convention**: a supplied `βs` is now interpreted the same way as in `aise` (inverse temperatures of the target, 0 → 1) and traversed in reverse internally. Uniform schedules such as the `range(0, 1, nbetas)` defaults are unchanged (they are symmetric); asymmetric adapted schedules can now be shared between `aise` and `raise` to sandwich `log(Z)`.

The core AIS/RAISE weight computation was reviewed against Burda, Grosse & Salakhutdinov (AISTATS 2015) and left as-is (it is correct; details in the session notes). None of the new names are added to the `public` set, consistent with keeping that set minimal.

## Empirical checks

**Bound validity** (small enumerable RBM with strong couplings, target samples drawn exactly by enumeration, 1000–2000 replicates, bounds tested at 3σ): `E[logmeanexp(aise)] < log Z < E[−logmeanexp(−raise)]` holds for uniform, pilot-adapted, and dynamically adapted schedules, and the sandwich tightens as the schedule grows — matching the paper's predictions. E.g. dynamic mode with `target = 0.7` (K ≈ 3, 10 chains): `13.333 ± 0.012 ≤ 13.464 ≤ 13.524 ± 0.010`.

**Accuracy at equal cost** (strongly coupled `BinaryRBM`, 20 replicates of `logmeanexp(aise(...))`, 100 samples, equal schedule length K = 36):

| schedule | bias | RMSE |
|---|---|---|
| adaptive (target 0.99) | −0.019 | **0.053** |
| uniform (`range(0, 1, 36)`) | −0.033 | 0.087 |

## Test plan

- New testsets in `test/ais.jl`: schedule validity (endpoints, sortedness, uniqueness, `max_betas` cap), accuracy of `aise`/`raise` with adapted and dynamic schedules vs exact `log_partition` (Binary and Gaussian RBMs), harder paths yield longer schedules, `steps` keyword, keyword mutual-exclusion and chain-count errors.
- JLArrays smoke tests in `test/jlarrays.jl` (`allowscalar(false)`), covering both adaptation modes.
- Full `Pkg.test()` suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKpcLTN4y56UaRiARcbq4F