### PR TITLE
v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.1.0
 
 - Removed `logmeanexp`, `logvarexp`, and `logstdexp` (not marked `public`). They
   now live in

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "6.0.1-DEV"
+version = "6.1.0"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Release commit for v6.1.0: drops the `-DEV` suffix from `version` in Project.toml and renames the `## Unreleased` CHANGELOG section to `## 6.1.0`.

Changes in this release (since v6.0.0):

- Removed `logmeanexp`, `logvarexp`, and `logstdexp` (not marked `public`). They now live in [LogStatFunctions.jl](https://github.com/cossio/LogStatFunctions.jl) with the same behavior ([#186](https://github.com/cossio/RestrictedBoltzmannMachines.jl/issues/186)).

After merging, Registrator will be triggered by a comment on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BijDFgLJLuY9E5Fu2ZZyjC

---
_Generated by [Claude Code](https://claude.ai/code/session_01BijDFgLJLuY9E5Fu2ZZyjC)_