### PR TITLE
Replace hand-rolled utilities with Base and LogExpFunctions equivalents

### DIFF
--- a/src/RestrictedBoltzmannMachines.jl
+++ b/src/RestrictedBoltzmannMachines.jl
@@ -6,7 +6,7 @@ using Adapt: Adapt, adapt
 using EllipsisNotation: (..)
 using FillArrays: Falses, Zeros, Ones
 using LinearAlgebra: Diagonal, dot, logdet
-using LogExpFunctions: log1pexp, logaddexp, logistic, logsumexp, softmax
+using LogExpFunctions: log1pexp, logaddexp, logistic, logit, logsumexp, softmax
 using Optimisers: AbstractRule, Adam, setup, update!
 using Random: AbstractRNG, default_rng, rand!, randexp, randn!, randperm
 using SpecialFunctions: erf, erfcx, logerfcx

--- a/src/layers/abstractlayer.jl
+++ b/src/layers/abstractlayer.jl
@@ -46,6 +46,13 @@ macro declare_layer(Layer, params)
 
     defaults = [Expr(:kw, name, :($init(T, sz))) for (name, init) in zip(names, inits)]
 
+    # Stack the parameters as rows of `par` via vcat of reshapes rather than
+    # `stack`: unlike `stack`, vcat stays inferable when the arguments mix
+    # container types (e.g. a view of `par` alongside a broadcast result) and
+    # has ChainRules rules, so Zygote can differentiate through layer
+    # conversions such as dReLU(::pReLU) that call this constructor.
+    rows = [:(reshape($name, 1, size($name)...)) for name in names]
+
     return esc(
         quote
             Base.@__doc__ struct $Layer{N, A} <: AbstractLayer{N}
@@ -60,7 +67,7 @@ macro declare_layer(Layer, params)
             end
 
             $Layer(par::AbstractArray) = $Layer{ndims(par) - 1, typeof(par)}(par)
-            $Layer(; $(names...)) = $Layer(vstack(($(names...),)))
+            $Layer(; $(names...)) = $Layer(vcat($(rows...)))
             $Layer(::Type{T}, sz::Dims) where {T} = $Layer(; $(defaults...))
             $Layer(sz::Dims) = $Layer(Float64, sz)
 

--- a/src/layers/common.jl
+++ b/src/layers/common.jl
@@ -23,19 +23,19 @@ end
 
 function ∂cgfs(layer::_FieldLayers, inputs = 0)
     ∂θ = mean_from_inputs(layer, inputs)
-    return vstack((∂θ,))
+    return stack([∂θ]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::_FieldLayers, moments::AbstractArray)
     @assert size(layer.par) == size(moments)
     x1 = moments[1, ..]
     ∂θ = -x1
-    return vstack((∂θ,))
+    return stack([∂θ]; dims = 1)
 end
 
 function moments_from_samples(layer::_FieldLayers, data::AbstractArray; wts = nothing)
     x1 = batchmean(layer, data; wts)
-    return vstack((x1,))
+    return stack([x1]; dims = 1)
 end
 
 """
@@ -124,5 +124,5 @@ function moments_from_samples(layer::Union{dReLU, pReLU, xReLU, nsReLU}, data::A
     xn1 = batchmean(layer, xn; wts)
     xp2 = batchmean(layer, xp .^ 2; wts)
     xn2 = batchmean(layer, xn .^ 2; wts)
-    return vstack((xp1, xn1, xp2, xn2))
+    return stack([xp1, xn1, xp2, xn2]; dims = 1)
 end

--- a/src/layers/drelu.jl
+++ b/src/layers/drelu.jl
@@ -74,7 +74,7 @@ function ∂cgfs(layer::dReLU, inputs = 0)
     ∂θn = -pn .* μn
     ∂γp = -pp .* μ2p .* sign.(layer.γp)
     ∂γn = -pn .* μ2n .* sign.(layer.γn)
-    return vstack((∂θp, ∂θn, ∂γp, ∂γn))
+    return stack([∂θp, ∂θn, ∂γp, ∂γn]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::dReLU, moments::AbstractArray)
@@ -83,7 +83,7 @@ function ∂energy_from_moments(layer::dReLU, moments::AbstractArray)
     ∂θn = -moments[2, ..]
     ∂γp = sign.(layer.γp) .* moments[3, ..] / 2
     ∂γn = sign.(layer.γn) .* moments[4, ..] / 2
-    return vstack((∂θp, ∂θn, ∂γp, ∂γn))
+    return stack([∂θp, ∂θn, ∂γp, ∂γn]; dims = 1)
 end
 
 function drelu_energy(θp::Real, θn::Real, γp::Real, γn::Real, x::Real)

--- a/src/layers/gaussian.jl
+++ b/src/layers/gaussian.jl
@@ -31,7 +31,7 @@ end
 function ∂cgfs(layer::Gaussian, inputs = 0)
     ∂θ = @. (layer.θ .+ inputs) / abs(layer.γ)
     ∂γ = @. -inv(layer.γ) / 2 - sign(layer.γ) * ∂θ^2 / 2
-    return vstack((∂θ, ∂γ))
+    return stack([∂θ, ∂γ]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::Gaussian, moments::AbstractArray)
@@ -40,11 +40,11 @@ function ∂energy_from_moments(layer::Gaussian, moments::AbstractArray)
     x2 = @view moments[2, ..]
     ∂θ = -x1
     ∂γ = @. sign(layer.γ) * x2 / 2
-    return vstack((∂θ, ∂γ))
+    return stack([∂θ, ∂γ]; dims = 1)
 end
 
 function moments_from_samples(layer::Gaussian, data::AbstractArray; wts = nothing)
     x1 = batchmean(layer, data; wts)
     x2 = batchmean(layer, data .^ 2; wts)
-    return vstack((x1, x2))
+    return stack([x1, x2]; dims = 1)
 end

--- a/src/layers/prelu.jl
+++ b/src/layers/prelu.jl
@@ -43,7 +43,7 @@ function ∂cgfs(layer::pReLU, inputs = 0)
             pn * (abs(layer.γ) * μ2n - layer.Δ * μn) / (1 - layer.η)^2
     )
 
-    return vstack((∂θ, ∂γ, ∂Δ, ∂η))
+    return stack([∂θ, ∂γ, ∂Δ, ∂η]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::pReLU, moments::AbstractArray)
@@ -63,5 +63,5 @@ function ∂energy_from_moments(layer::pReLU, moments::AbstractArray)
             (abs(layer.γ) * xn2 / 2 + layer.Δ * xn1) / (1 - layer.η)^2
     )
 
-    return vstack((∂θ, ∂γ, ∂Δ, ∂η))
+    return stack([∂θ, ∂γ, ∂Δ, ∂η]; dims = 1)
 end

--- a/src/layers/relu.jl
+++ b/src/layers/relu.jl
@@ -42,7 +42,7 @@ function ∂cgfs(layer::ReLU, inputs = 0)
     μ, ν = meanvar_from_inputs(layer, inputs)
     ∂θ = μ
     ∂γ = -sign.(layer.γ) .* (ν .+ μ .^ 2) / 2
-    return vstack((∂θ, ∂γ))
+    return stack([∂θ, ∂γ]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::ReLU, moments::AbstractArray)
@@ -55,7 +55,7 @@ end
 
 function relu_energy(θ::Real, γ::Real, x::Real)
     E = gauss_energy(θ, γ, x)
-    return x < 0 ? inf(E) : E
+    return x < 0 ? oftype(E, Inf) : E
 end
 
 function relu_cgf(θ::Real, γ::Real)

--- a/src/layers/spin.jl
+++ b/src/layers/spin.jl
@@ -34,9 +34,6 @@ function sample_from_inputs(layer::Spin, inputs = 0)
     return spin_rand.(θ, u)
 end
 
-function spin_cgf(θ::Real)
-    abs_θ = abs(θ)
-    return abs_θ + log1pexp(-2abs_θ)
-end
+spin_cgf(θ::Real) = logaddexp(θ, -θ) # log(exp(θ) + exp(-θ))
 
 spin_rand(θ::Real, u::Real) = ifelse(u < logistic(2θ), Int8(1), Int8(-1))

--- a/src/layers/xrelu.jl
+++ b/src/layers/xrelu.jl
@@ -31,7 +31,7 @@ function ∂cgfs(layer::xReLU, inputs = 0)
             pn * (abs_γ / 2 * μ2n - layer.Δ * μn) / (1 - layer.ξ + abs(layer.ξ))^2
     )
 
-    return vstack((∂θ, ∂γ, ∂Δ, ∂ξ))
+    return stack([∂θ, ∂γ, ∂Δ, ∂ξ]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::xReLU, moments::AbstractArray)
@@ -52,5 +52,5 @@ function ∂energy_from_moments(layer::xReLU, moments::AbstractArray)
             (abs(layer.γ) / 2 * xn2 + layer.Δ * xn1) / (1 - layer.ξ + abs(layer.ξ))^2
     )
 
-    return vstack((∂θ, ∂γ, ∂Δ, ∂ξ))
+    return stack([∂θ, ∂γ, ∂Δ, ∂ξ]; dims = 1)
 end

--- a/src/partition.jl
+++ b/src/partition.jl
@@ -53,7 +53,5 @@ Only defined for discrete layers.
     For large layers, the exponential number of states will not fit in memory.
 """
 function collect_states(layer::Union{Binary, Spin})
-    return reduce(iterate_states(layer)) do x, y
-        cat(x, y; dims = ndims(layer) + 1)
-    end
+    return reshape(stack(iterate_states(layer)), size(layer)..., :)
 end

--- a/src/train/initialization.jl
+++ b/src/train/initialization.jl
@@ -34,7 +34,7 @@ function initialize!(layer::Binary, data::AbstractArray; ϵ::Real = 1.0e-6, wts 
     @assert 0 < ϵ < 1 / 2
     μ = batchmean(layer, data; wts)
     μϵ = clamp.(μ, ϵ, 1 - ϵ)
-    @. layer.θ = -log(1 / μϵ - 1)
+    layer.θ .= logit.(μϵ)
     return layer
 end
 

--- a/src/util/truncated_normal.jl
+++ b/src/util/truncated_normal.jl
@@ -42,14 +42,9 @@ end
 
 Accurate computation of sqrt(1 + (x/2)^2) + |x|/2.
 """
-sqrt1half(x::Real) = _sqrt1half(float(abs(x)))
-
-function _sqrt1half(x::Real)
-    if x > 2 / sqrt(eps(x))
-        return x
-    else
-        return sqrt(one(x) + (x / 2)^2) + x / 2
-    end
+function sqrt1half(x::Real)
+    h = abs(float(x)) / 2
+    return hypot(one(h), h) + h
 end
 
 """
@@ -71,7 +66,10 @@ randnt_half(μ::Real, σ::Real) = randnt_half(default_rng(), μ, σ)
 Mean of the standard normal distribution,
 truncated to the interval (a, +∞).
 """
-tnmean(a::Real) = sqrt(two(a) / π) / erfcx(a / √two(a))
+function tnmean(a::Real)
+    t = oftype(float(a), 2)
+    return sqrt(t / π) / erfcx(a / sqrt(t))
+end
 
 """
     tnvar(a)

--- a/src/util/util.jl
+++ b/src/util/util.jl
@@ -1,7 +1,3 @@
-# convenience functions to get generic Inf and NaN
-inf(::Union{Type{T}, T}) where {T <: Number} = convert(T, Inf)
-two(::Union{Type{T}, T}) where {T <: Number} = convert(T, 2)
-
 @doc raw"""
     wmean(A; wts = nothing, dims = :)
 
@@ -62,23 +58,6 @@ reshape_maybe(x::Number, ::Tuple{}) = x
 reshape_maybe(x::AbstractArray, ::Tuple{}) = only(x)
 reshape_maybe(x::AbstractArray, sz::Dims) = reshape(x, sz)
 reshape_maybe(x::Union{Number, AbstractArray}, sz::Int...) = reshape(x, sz)
-
-"""
-    vstack(x)
-
-Stack arrays along a new dimension inserted on the left.
-"""
-function vstack(xs::Tuple)
-    ys = map(vwiden, xs)
-    return vcat(ys...)
-end
-
-"""
-    vwiden(x)
-
-Adds a singleton dimension on the left.
-"""
-vwiden(x::AbstractArray) = reshape(x, 1, size(x)...)
 
 zeros_like(A::AbstractArray) = zeros_like(A, size(A))
 zeros_like(A::AbstractArray, size) = zero(similar(A, size))

--- a/test/layers.jl
+++ b/test/layers.jl
@@ -11,7 +11,7 @@ using RestrictedBoltzmannMachines: RBM, Binary, Spin, Potts, Gaussian, ReLU, dRe
     flatten, batch_size, batchmean, batchvar, batchcov, drelu_energy,
     mean_from_inputs, var_from_inputs, meanvar_from_inputs, batchdims, gauss_energy, relu_energy,
     std_from_inputs, mean_abs_from_inputs, sample_from_inputs, mode_from_inputs,
-    energy, cgf, free_energy, cgfs, energies, ∂cgf, vstack, ∂energy, ∂free_energy, binary_rand,
+    energy, cgf, free_energy, cgfs, energies, ∂cgf, ∂energy, ∂free_energy, binary_rand,
     total_meanvar_from_inputs, total_mean_from_inputs, total_var_from_inputs, sample_v_from_v
 using RestrictedBoltzmannMachines: grad2ave
 using RestrictedBoltzmannMachines: grad2var
@@ -137,7 +137,7 @@ end
     gs = Zygote.gradient(layer) do layer
         sum(cgfs(layer))
     end
-    @test ∂cgf(layer) ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂cgf(layer) ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
 end
 
 @testset "Binary" begin
@@ -159,7 +159,7 @@ end
         sum(cgfs(layer))
     end
     ∂ = ∂cgf(layer)
-    @test ∂ ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂ ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
     @test grad2ave(layer, ∂) ≈ mean_from_inputs(layer)
     @test grad2var(layer, ∂) ≈ var_from_inputs(layer)
 end
@@ -173,7 +173,7 @@ end
         sum(cgfs(layer))
     end
     ∂ = ∂cgf(layer)
-    @test ∂ ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂ ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
     @test grad2ave(layer, ∂) ≈ mean_from_inputs(layer)
     @test grad2var(layer, ∂) ≈ var_from_inputs(layer)
 end
@@ -192,7 +192,7 @@ end
         sum(cgfs(layer))
     end
     ∂ = ∂cgf(layer)
-    @test ∂ ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂ ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
     @test grad2ave(layer, ∂) ≈ mean_from_inputs(layer)
     @test grad2var(layer, ∂) ≈ var_from_inputs(layer)
 end

--- a/test/pottsgumbel.jl
+++ b/test/pottsgumbel.jl
@@ -32,7 +32,6 @@ using RestrictedBoltzmannMachines: sample_from_inputs
 using RestrictedBoltzmannMachines: sample_v_from_v
 using RestrictedBoltzmannMachines: std_from_inputs
 using RestrictedBoltzmannMachines: var_from_inputs
-using RestrictedBoltzmannMachines: vstack
 using Statistics: cov
 using Statistics: mean
 using Statistics: var
@@ -140,7 +139,7 @@ end
     gs = Zygote.gradient(layer) do layer
         sum(cgfs(layer))
     end
-    @test ∂cgf(layer) ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂cgf(layer) ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
 end
 
 @testset "PottsGumbel" begin
@@ -157,7 +156,7 @@ end
         sum(cgfs(layer))
     end
     ∂ = ∂cgf(layer)
-    @test ∂ ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂ ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
     @test grad2ave(layer, ∂) ≈ mean_from_inputs(layer)
     # one-hot units are Bernoulli per color, so the variance follows from the mean
     @test grad2var(layer, ∂) ≈ var_from_inputs(layer)

--- a/test/util.jl
+++ b/test/util.jl
@@ -3,24 +3,7 @@ import RestrictedBoltzmannMachines as RBMs
 using Test: @test, @testset, @inferred, @test_throws
 using Statistics: mean, var, cov
 using LinearAlgebra: dot
-using EllipsisNotation: (..)
-using RestrictedBoltzmannMachines: vstack, convert_eltype
-
-@testset "two" begin
-    @test RBMs.two(1) === RBMs.two(Int) === 2
-    @test RBMs.two(Int8(1)) === RBMs.two(Int8) === Int8(2)
-    @test RBMs.two(1.0f0) === RBMs.two(Float32) === 2.0f0
-    @test RBMs.two(1.0) === RBMs.two(Float64) === 2.0
-    @test_throws InexactError RBMs.two(Bool)
-    @inferred RBMs.two(1)
-end
-
-@testset "inf" begin
-    @test_throws InexactError RBMs.inf(1)
-    @test Inf === @inferred RBMs.inf(1.0)
-    @test Inf32 === @inferred RBMs.inf(1.0f0)
-    @inferred RBMs.inf(1.0)
-end
+using RestrictedBoltzmannMachines: convert_eltype
 
 @testset "generate_sequences" begin
     @test collect(RBMs.generate_sequences(2, 1:3)) == reshape(
@@ -70,15 +53,6 @@ end
 
     A = randn(2, 2)
     @test RBMs.reshape_maybe(A, 4) == reshape(A, 4)
-end
-
-@testset "vstack" begin
-    X = randn(3, 4)
-    Y = randn(3, 4)
-    Z = @inferred vstack((X, Y))
-    @test size(Z) == (2, 3, 4)
-    @test Z[1, ..] == X
-    @test Z[2, ..] == Y
 end
 
 @testset "convert_eltype" begin


### PR DESCRIPTION
Consolidates internal utility functions onto library or standard-library equivalents, after a survey of every helper in `src/`. All replacements are behavior-preserving (verified against the old formulas, including edge cases).

## Implemented replacements

- **`vstack` / `vwiden` → `Base.stack(...; dims = 1)`** at the gradient/moment sites (`∂cgfs`, `∂energy_from_moments`, `moments_from_samples`), where the stacked arrays are homogeneous broadcast results. The `@declare_layer` keyword constructor instead inlines the equivalent `vcat`-of-reshapes with a comment explaining why: ChainRules has an `rrule` for `stack(::AbstractArray)` but not for tuple arguments (so Zygote fails differentiating through layer conversions like `dReLU(::pReLU)`), and `stack` over a `Vector` loses type inference when the parameters mix container types (a view of `par` alongside a broadcast result), which is common in `shift_fields`, `anneal_zero`, and `_drelu_mixture_moments`. `vcat` satisfies all constraints.
- **`spin_cgf`** now delegates to `LogExpFunctions.logaddexp(θ, -θ)`, whose implementation is the identical `|θ| + log1pexp(-2|θ|)` formula (bit-identical results, checked including `±Inf` and `Float32`).
- **`initialize!(::Binary)`** uses `LogExpFunctions.logit` instead of the hand-written `-log(1/μ - 1)`.
- **`sqrt1half`** uses `Base.hypot`, which handles the large-argument overflow that previously required an eps-based guard branch (`_sqrt1half` deleted; existing edge-case tests for `0`, `±1`, `NaN`, `±Inf`, `1e300`, and `Float32` still pass).
- **`inf` / `two`** type-preserving helpers deleted in favor of `Base.oftype` at their two call sites (`relu_energy`, `tnmean`); value semantics are identical.
- **`collect_states`** uses `Base.stack` instead of a quadratic `reduce`-with-`cat`, keeping the same output shape, eltype, and state order.

## Considered and deliberately not replaced

- `wmean` (StatsBase `mean(A, weights(w))`): would add a dependency and lose the overflow-safe normalization and exact zero-weight annihilation that `test/zero_weight_training.jl` relies on.
- `nobs`/`getobs`/`shuffleobs`/`infinite_minibatches` (MLUtils.jl duplicates these APIs): would add a fairly heavy dependency for ~60 lines; left to a maintainer decision.
- `categorical_rand`/`categorical_sample`, `onehot_encode`/`onehot_decode` (Distributions.jl / OneHotArrays.jl): new dependencies, different data structures.
- `randnt` is a documented, deliberately specialized adaptation of Distributions.jl's sampler (avoids the CDF overhead), kept as-is.
- `_mutable_copy` is exactly `Base.copymutable`, but that name is not public API, so the local helper stays.

## Testing

- Full test suite via `Pkg.test()`.
- Focused runs of `test/layers.jl`, `test/pottsgumbel.jl`, `test/util.jl`, `test/truncnorm.jl`, `test/onehot.jl`, and `test/jlarrays.jl` (JLArrays with `allowscalar(false)`, confirming `Base.stack` is GPU-safe).
- No CHANGELOG entry: internal refactor with no user-facing API or behavior change (none of the removed helpers are in the package's `public` list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnXNNAHv6rrGzMSbE4FbSL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnXNNAHv6rrGzMSbE4FbSL)_