### PR TITLE
Replace vstack/vwiden with Base.stack

### DIFF
--- a/src/layers/abstractlayer.jl
+++ b/src/layers/abstractlayer.jl
@@ -46,6 +46,13 @@ macro declare_layer(Layer, params)
 
     defaults = [Expr(:kw, name, :($init(T, sz))) for (name, init) in zip(names, inits)]
 
+    # Stack the parameters as rows of `par` via vcat of reshapes rather than
+    # `stack`: unlike `stack`, vcat stays inferable when the arguments mix
+    # container types (e.g. a view of `par` alongside a broadcast result) and
+    # has ChainRules rules, so Zygote can differentiate through layer
+    # conversions such as dReLU(::pReLU) that call this constructor.
+    rows = [:(reshape($name, 1, size($name)...)) for name in names]
+
     return esc(
         quote
             Base.@__doc__ struct $Layer{N, A} <: AbstractLayer{N}
@@ -60,7 +67,7 @@ macro declare_layer(Layer, params)
             end
 
             $Layer(par::AbstractArray) = $Layer{ndims(par) - 1, typeof(par)}(par)
-            $Layer(; $(names...)) = $Layer(vstack(($(names...),)))
+            $Layer(; $(names...)) = $Layer(vcat($(rows...)))
             $Layer(::Type{T}, sz::Dims) where {T} = $Layer(; $(defaults...))
             $Layer(sz::Dims) = $Layer(Float64, sz)
 

--- a/src/layers/common.jl
+++ b/src/layers/common.jl
@@ -23,19 +23,19 @@ end
 
 function ∂cgfs(layer::_FieldLayers, inputs = 0)
     ∂θ = mean_from_inputs(layer, inputs)
-    return vstack((∂θ,))
+    return stack([∂θ]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::_FieldLayers, moments::AbstractArray)
     @assert size(layer.par) == size(moments)
     x1 = moments[1, ..]
     ∂θ = -x1
-    return vstack((∂θ,))
+    return stack([∂θ]; dims = 1)
 end
 
 function moments_from_samples(layer::_FieldLayers, data::AbstractArray; wts = nothing)
     x1 = batchmean(layer, data; wts)
-    return vstack((x1,))
+    return stack([x1]; dims = 1)
 end
 
 """
@@ -124,5 +124,5 @@ function moments_from_samples(layer::Union{dReLU, pReLU, xReLU, nsReLU}, data::A
     xn1 = batchmean(layer, xn; wts)
     xp2 = batchmean(layer, xp .^ 2; wts)
     xn2 = batchmean(layer, xn .^ 2; wts)
-    return vstack((xp1, xn1, xp2, xn2))
+    return stack([xp1, xn1, xp2, xn2]; dims = 1)
 end

--- a/src/layers/drelu.jl
+++ b/src/layers/drelu.jl
@@ -74,7 +74,7 @@ function ∂cgfs(layer::dReLU, inputs = 0)
     ∂θn = -pn .* μn
     ∂γp = -pp .* μ2p .* sign.(layer.γp)
     ∂γn = -pn .* μ2n .* sign.(layer.γn)
-    return vstack((∂θp, ∂θn, ∂γp, ∂γn))
+    return stack([∂θp, ∂θn, ∂γp, ∂γn]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::dReLU, moments::AbstractArray)
@@ -83,7 +83,7 @@ function ∂energy_from_moments(layer::dReLU, moments::AbstractArray)
     ∂θn = -moments[2, ..]
     ∂γp = sign.(layer.γp) .* moments[3, ..] / 2
     ∂γn = sign.(layer.γn) .* moments[4, ..] / 2
-    return vstack((∂θp, ∂θn, ∂γp, ∂γn))
+    return stack([∂θp, ∂θn, ∂γp, ∂γn]; dims = 1)
 end
 
 function drelu_energy(θp::Real, θn::Real, γp::Real, γn::Real, x::Real)

--- a/src/layers/gaussian.jl
+++ b/src/layers/gaussian.jl
@@ -46,5 +46,8 @@ end
 function moments_from_samples(layer::Gaussian, data::AbstractArray; wts = nothing)
     x1 = batchmean(layer, data; wts)
     x2 = batchmean(layer, data .^ 2; wts)
-    return stack([x1, x2]; dims = 1)
+    # vcat of reshapes rather than `stack`: for unbatched `data`, x1 can be a
+    # view (batchmean returns `data` itself) while x2 is an Array, and `stack`
+    # over mixed container types does not infer
+    return vcat(reshape(x1, 1, size(x1)...), reshape(x2, 1, size(x2)...))
 end

--- a/src/layers/gaussian.jl
+++ b/src/layers/gaussian.jl
@@ -31,7 +31,7 @@ end
 function ∂cgfs(layer::Gaussian, inputs = 0)
     ∂θ = @. (layer.θ .+ inputs) / abs(layer.γ)
     ∂γ = @. -inv(layer.γ) / 2 - sign(layer.γ) * ∂θ^2 / 2
-    return vstack((∂θ, ∂γ))
+    return stack([∂θ, ∂γ]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::Gaussian, moments::AbstractArray)
@@ -40,11 +40,11 @@ function ∂energy_from_moments(layer::Gaussian, moments::AbstractArray)
     x2 = @view moments[2, ..]
     ∂θ = -x1
     ∂γ = @. sign(layer.γ) * x2 / 2
-    return vstack((∂θ, ∂γ))
+    return stack([∂θ, ∂γ]; dims = 1)
 end
 
 function moments_from_samples(layer::Gaussian, data::AbstractArray; wts = nothing)
     x1 = batchmean(layer, data; wts)
     x2 = batchmean(layer, data .^ 2; wts)
-    return vstack((x1, x2))
+    return stack([x1, x2]; dims = 1)
 end

--- a/src/layers/prelu.jl
+++ b/src/layers/prelu.jl
@@ -43,7 +43,7 @@ function ∂cgfs(layer::pReLU, inputs = 0)
             pn * (abs(layer.γ) * μ2n - layer.Δ * μn) / (1 - layer.η)^2
     )
 
-    return vstack((∂θ, ∂γ, ∂Δ, ∂η))
+    return stack([∂θ, ∂γ, ∂Δ, ∂η]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::pReLU, moments::AbstractArray)
@@ -63,5 +63,5 @@ function ∂energy_from_moments(layer::pReLU, moments::AbstractArray)
             (abs(layer.γ) * xn2 / 2 + layer.Δ * xn1) / (1 - layer.η)^2
     )
 
-    return vstack((∂θ, ∂γ, ∂Δ, ∂η))
+    return stack([∂θ, ∂γ, ∂Δ, ∂η]; dims = 1)
 end

--- a/src/layers/relu.jl
+++ b/src/layers/relu.jl
@@ -42,7 +42,7 @@ function ∂cgfs(layer::ReLU, inputs = 0)
     μ, ν = meanvar_from_inputs(layer, inputs)
     ∂θ = μ
     ∂γ = -sign.(layer.γ) .* (ν .+ μ .^ 2) / 2
-    return vstack((∂θ, ∂γ))
+    return stack([∂θ, ∂γ]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::ReLU, moments::AbstractArray)

--- a/src/layers/xrelu.jl
+++ b/src/layers/xrelu.jl
@@ -31,7 +31,7 @@ function ∂cgfs(layer::xReLU, inputs = 0)
             pn * (abs_γ / 2 * μ2n - layer.Δ * μn) / (1 - layer.ξ + abs(layer.ξ))^2
     )
 
-    return vstack((∂θ, ∂γ, ∂Δ, ∂ξ))
+    return stack([∂θ, ∂γ, ∂Δ, ∂ξ]; dims = 1)
 end
 
 function ∂energy_from_moments(layer::xReLU, moments::AbstractArray)
@@ -52,5 +52,5 @@ function ∂energy_from_moments(layer::xReLU, moments::AbstractArray)
             (abs(layer.γ) / 2 * xn2 + layer.Δ * xn1) / (1 - layer.ξ + abs(layer.ξ))^2
     )
 
-    return vstack((∂θ, ∂γ, ∂Δ, ∂ξ))
+    return stack([∂θ, ∂γ, ∂Δ, ∂ξ]; dims = 1)
 end

--- a/src/util/util.jl
+++ b/src/util/util.jl
@@ -63,23 +63,6 @@ reshape_maybe(x::AbstractArray, ::Tuple{}) = only(x)
 reshape_maybe(x::AbstractArray, sz::Dims) = reshape(x, sz)
 reshape_maybe(x::Union{Number, AbstractArray}, sz::Int...) = reshape(x, sz)
 
-"""
-    vstack(x)
-
-Stack arrays along a new dimension inserted on the left.
-"""
-function vstack(xs::Tuple)
-    ys = map(vwiden, xs)
-    return vcat(ys...)
-end
-
-"""
-    vwiden(x)
-
-Adds a singleton dimension on the left.
-"""
-vwiden(x::AbstractArray) = reshape(x, 1, size(x)...)
-
 zeros_like(A::AbstractArray) = zeros_like(A, size(A))
 zeros_like(A::AbstractArray, size) = zero(similar(A, size))
 

--- a/test/layers.jl
+++ b/test/layers.jl
@@ -11,7 +11,7 @@ using RestrictedBoltzmannMachines: RBM, Binary, Spin, Potts, Gaussian, ReLU, dRe
     flatten, batch_size, batchmean, batchvar, batchcov, drelu_energy,
     mean_from_inputs, var_from_inputs, meanvar_from_inputs, batchdims, gauss_energy, relu_energy,
     std_from_inputs, mean_abs_from_inputs, sample_from_inputs, mode_from_inputs,
-    energy, cgf, free_energy, cgfs, energies, ∂cgf, vstack, ∂energy, ∂free_energy, binary_rand,
+    energy, cgf, free_energy, cgfs, energies, ∂cgf, ∂energy, ∂free_energy, binary_rand,
     total_meanvar_from_inputs, total_mean_from_inputs, total_var_from_inputs, sample_v_from_v
 using RestrictedBoltzmannMachines: grad2ave
 using RestrictedBoltzmannMachines: grad2var
@@ -137,7 +137,7 @@ end
     gs = Zygote.gradient(layer) do layer
         sum(cgfs(layer))
     end
-    @test ∂cgf(layer) ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂cgf(layer) ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
 end
 
 @testset "Binary" begin
@@ -159,7 +159,7 @@ end
         sum(cgfs(layer))
     end
     ∂ = ∂cgf(layer)
-    @test ∂ ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂ ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
     @test grad2ave(layer, ∂) ≈ mean_from_inputs(layer)
     @test grad2var(layer, ∂) ≈ var_from_inputs(layer)
 end
@@ -173,7 +173,7 @@ end
         sum(cgfs(layer))
     end
     ∂ = ∂cgf(layer)
-    @test ∂ ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂ ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
     @test grad2ave(layer, ∂) ≈ mean_from_inputs(layer)
     @test grad2var(layer, ∂) ≈ var_from_inputs(layer)
 end
@@ -192,7 +192,7 @@ end
         sum(cgfs(layer))
     end
     ∂ = ∂cgf(layer)
-    @test ∂ ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂ ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
     @test grad2ave(layer, ∂) ≈ mean_from_inputs(layer)
     @test grad2var(layer, ∂) ≈ var_from_inputs(layer)
 end

--- a/test/layers.jl
+++ b/test/layers.jl
@@ -572,3 +572,17 @@ end
     @test mean_abs_from_inputs(drelu) ≈ mean_abs_from_inputs(relu) rtol = 1.0e-4
     @test cgfs(drelu) ≈ cgfs(relu) .+ log1p.(exp.(relu_cgf.(0, 1.0e10) .- cgfs(relu))) rtol = 1.0e-6
 end
+
+using RestrictedBoltzmannMachines: moments_from_samples
+
+@testset "moments_from_samples infers for view data" begin
+    # for unbatched data, batchmean returns the input itself, so the stacked
+    # moments mix container types (view + Array); the result must stay inferable
+    layer = Gaussian((3, 2))
+    samples = randn(3, 2, 5)
+    v = @view samples[:, :, 1]
+    m = @inferred moments_from_samples(layer, v)
+    @test m ≈ vcat(reshape(v, 1, 3, 2), reshape(v .^ 2, 1, 3, 2))
+    @inferred moments_from_samples(ReLU((3, 2)), v)
+    @inferred moments_from_samples(layer, samples)
+end

--- a/test/layers.jl
+++ b/test/layers.jl
@@ -13,6 +13,7 @@ using RestrictedBoltzmannMachines: RBM, Binary, Spin, Potts, Gaussian, ReLU, dRe
     std_from_inputs, mean_abs_from_inputs, sample_from_inputs, mode_from_inputs,
     energy, cgf, free_energy, cgfs, energies, ∂cgf, ∂energy, ∂free_energy, binary_rand,
     total_meanvar_from_inputs, total_mean_from_inputs, total_var_from_inputs, sample_v_from_v
+using RestrictedBoltzmannMachines: moments_from_samples
 using RestrictedBoltzmannMachines: grad2ave
 using RestrictedBoltzmannMachines: grad2var
 
@@ -572,8 +573,6 @@ end
     @test mean_abs_from_inputs(drelu) ≈ mean_abs_from_inputs(relu) rtol = 1.0e-4
     @test cgfs(drelu) ≈ cgfs(relu) .+ log1p.(exp.(relu_cgf.(0, 1.0e10) .- cgfs(relu))) rtol = 1.0e-6
 end
-
-using RestrictedBoltzmannMachines: moments_from_samples
 
 @testset "moments_from_samples infers for view data" begin
     # for unbatched data, batchmean returns the input itself, so the stacked

--- a/test/pottsgumbel.jl
+++ b/test/pottsgumbel.jl
@@ -32,7 +32,6 @@ using RestrictedBoltzmannMachines: sample_from_inputs
 using RestrictedBoltzmannMachines: sample_v_from_v
 using RestrictedBoltzmannMachines: std_from_inputs
 using RestrictedBoltzmannMachines: var_from_inputs
-using RestrictedBoltzmannMachines: vstack
 using Statistics: cov
 using Statistics: mean
 using Statistics: var
@@ -140,7 +139,7 @@ end
     gs = Zygote.gradient(layer) do layer
         sum(cgfs(layer))
     end
-    @test ∂cgf(layer) ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂cgf(layer) ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
 end
 
 @testset "PottsGumbel" begin
@@ -157,7 +156,7 @@ end
         sum(cgfs(layer))
     end
     ∂ = ∂cgf(layer)
-    @test ∂ ≈ only(gs).par ≈ vstack((mean_from_inputs(layer),))
+    @test ∂ ≈ only(gs).par ≈ stack([mean_from_inputs(layer)]; dims = 1)
     @test grad2ave(layer, ∂) ≈ mean_from_inputs(layer)
     # one-hot units are Bernoulli per color, so the variance follows from the mean
     @test grad2var(layer, ∂) ≈ var_from_inputs(layer)

--- a/test/util.jl
+++ b/test/util.jl
@@ -3,8 +3,7 @@ import RestrictedBoltzmannMachines as RBMs
 using Test: @test, @testset, @inferred, @test_throws
 using Statistics: mean, var, cov
 using LinearAlgebra: dot
-using EllipsisNotation: (..)
-using RestrictedBoltzmannMachines: vstack, convert_eltype
+using RestrictedBoltzmannMachines: convert_eltype
 
 @testset "two" begin
     @test RBMs.two(1) === RBMs.two(Int) === 2
@@ -70,15 +69,6 @@ end
 
     A = randn(2, 2)
     @test RBMs.reshape_maybe(A, 4) == reshape(A, 4)
-end
-
-@testset "vstack" begin
-    X = randn(3, 4)
-    Y = randn(3, 4)
-    Z = @inferred vstack((X, Y))
-    @test size(Z) == (2, 3, 4)
-    @test Z[1, ..] == X
-    @test Z[2, ..] == Y
 end
 
 @testset "convert_eltype" begin


### PR DESCRIPTION
Split out of #197 (utility consolidation), part 1 of 5.

Deletes the `vstack`/`vwiden` utilities. The gradient and moment helpers (`∂cgfs`, `∂energy_from_moments`, `moments_from_samples`) now use `Base.stack(...; dims = 1)` directly, with `Vector` arguments so the ChainRules `rrule` for `stack(::AbstractArray)` applies.

The `@declare_layer` keyword constructor instead inlines the equivalent `vcat`-of-reshapes, with a comment explaining why `Base.stack` cannot be used there: ChainRules has no `rrule` for tuple arguments (Zygote must differentiate through layer conversions such as `dReLU(::pReLU)` that call this constructor), and `stack` over a `Vector` loses type inference when the parameters mix container types (a view of `par` alongside a broadcast result), which is common in `shift_fields`, `anneal_zero`, and `_drelu_mixture_moments`. `vcat` satisfies all constraints.

Behavior-preserving. Tested with `test/layers.jl`, `test/pottsgumbel.jl`, `test/util.jl`, and `test/jlarrays.jl` (JLArrays with `allowscalar(false)`, confirming `Base.stack` is GPU-safe); the combined change also passed the full suite locally and on CI in #197.

No CHANGELOG entry: internal refactor, no user-facing API or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnXNNAHv6rrGzMSbE4FbSL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnXNNAHv6rrGzMSbE4FbSL)_