### PR TITLE
Use LogExpFunctions logaddexp and logit in spin cgf and Binary initialization

### DIFF
--- a/src/RestrictedBoltzmannMachines.jl
+++ b/src/RestrictedBoltzmannMachines.jl
@@ -6,7 +6,7 @@ using Adapt: Adapt, adapt
 using EllipsisNotation: (..)
 using FillArrays: Falses, Zeros, Ones
 using LinearAlgebra: Diagonal, dot, logdet
-using LogExpFunctions: log1pexp, logaddexp, logistic, logsumexp, softmax
+using LogExpFunctions: log1pexp, logaddexp, logistic, logit, logsumexp, softmax
 using Optimisers: AbstractRule, Adam, setup, update!
 using Random: AbstractRNG, default_rng, rand!, randexp, randn!, randperm
 using SpecialFunctions: erf, erfcx, logerfcx

--- a/src/layers/spin.jl
+++ b/src/layers/spin.jl
@@ -34,9 +34,6 @@ function sample_from_inputs(layer::Spin, inputs = 0)
     return spin_rand.(θ, u)
 end
 
-function spin_cgf(θ::Real)
-    abs_θ = abs(θ)
-    return abs_θ + log1pexp(-2abs_θ)
-end
+spin_cgf(θ::Real) = logaddexp(θ, -θ) # log(exp(θ) + exp(-θ))
 
 spin_rand(θ::Real, u::Real) = ifelse(u < logistic(2θ), Int8(1), Int8(-1))

--- a/src/train/initialization.jl
+++ b/src/train/initialization.jl
@@ -34,7 +34,7 @@ function initialize!(layer::Binary, data::AbstractArray; ϵ::Real = 1.0e-6, wts 
     @assert 0 < ϵ < 1 / 2
     μ = batchmean(layer, data; wts)
     μϵ = clamp.(μ, ϵ, 1 - ϵ)
-    @. layer.θ = -log(1 / μϵ - 1)
+    layer.θ .= logit.(μϵ)
     return layer
 end
 


### PR DESCRIPTION
Split out of #197 (utility consolidation), part 2 of 5.

Two hand-written formulas delegate to LogExpFunctions (already a dependency):

- `spin_cgf` now calls `logaddexp(θ, -θ)`, whose implementation is the identical `|θ| + log1pexp(-2|θ|)` formula — bit-identical results, verified including `±Inf` and `Float32`.
- `initialize!(::Binary)` uses `logit` instead of the hand-written `-log(1/μ - 1)` (same function, and `logit` is the standard, numerically careful spelling).

Behavior-preserving. Tested with `test/layers.jl` (covers `spin_cgf` directly) and `test/initialization.jl`; the combined change also passed the full suite locally and on CI in #197.

No CHANGELOG entry: internal refactor, no user-facing API or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnXNNAHv6rrGzMSbE4FbSL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnXNNAHv6rrGzMSbE4FbSL)_