### PR TITLE
Use Base.hypot in sqrt1half

### DIFF
--- a/src/util/truncated_normal.jl
+++ b/src/util/truncated_normal.jl
@@ -43,8 +43,8 @@ end
 Accurate computation of sqrt(1 + (x/2)^2) + |x|/2.
 """
 function sqrt1half(x::Real)
-    h = abs(float(x)) / 2
-    return hypot(one(h), h) + h
+    h = x / 2
+    return hypot(one(h), h) + abs(h)
 end
 
 """

--- a/src/util/truncated_normal.jl
+++ b/src/util/truncated_normal.jl
@@ -42,14 +42,9 @@ end
 
 Accurate computation of sqrt(1 + (x/2)^2) + |x|/2.
 """
-sqrt1half(x::Real) = _sqrt1half(float(abs(x)))
-
-function _sqrt1half(x::Real)
-    if x > 2 / sqrt(eps(x))
-        return x
-    else
-        return sqrt(one(x) + (x / 2)^2) + x / 2
-    end
+function sqrt1half(x::Real)
+    h = abs(float(x)) / 2
+    return hypot(one(h), h) + h
 end
 
 """


### PR DESCRIPTION
Split out of #197 (utility consolidation), part 3 of 5.

`sqrt1half(x)` computes `sqrt(1 + (x/2)^2) + |x|/2`. `Base.hypot` handles the large-argument overflow that previously required an eps-based guard branch, so `_sqrt1half` is deleted and the function body becomes `hypot(1, |x|/2) + |x|/2`.

Behavior-preserving: the existing edge-case tests (`0`, `±1`, `NaN`, `±Inf`, `1e300`, `Float32` type preservation) in `test/truncnorm.jl` all pass unchanged. The combined change also passed the full suite locally and on CI in #197.

No CHANGELOG entry: internal refactor, no user-facing API or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnXNNAHv6rrGzMSbE4FbSL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnXNNAHv6rrGzMSbE4FbSL)_