### PR TITLE
Run CI and Runic once per PR commit instead of twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,7 +1,9 @@
 name: Runic formatting
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary

Follow-up to #203. The `CI` and `Runic formatting` workflows triggered on both bare `push` and `pull_request`, so every commit pushed to an open PR ran each job twice — once for the branch head (`push`) and once for the merge preview (`pull_request`). This limits their `push` trigger to `master`:

```yaml
on:
  push:
    branches:
      - master
  pull_request:
```

This matches the pattern already used by the `Agent docs` and `Documentation` workflows; the remaining workflows are event-driven and unaffected.

## Behavior after this change

- Each new commit on an open PR still gets one run per workflow, via the `pull_request` `synchronize` event (testing the merge preview against `master`).
- `master` still runs after each merge.
- Branches pushed without an open PR no longer trigger these workflows — open a PR (draft is enough) to get CI.
- Tag pushes no longer trigger `CI` (previously they did via the bare `push` trigger); `Documentation` retains its own `tags: [v*]` trigger for docs deployment.

Required status checks are unaffected: both event variants report the same job names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiSBZGMi78zjnCzwYGFA38

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiSBZGMi78zjnCzwYGFA38)_