### PR TITLE
Fix GPU exact pseudolikelihood for Potts visible layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Fixed `log_pseudolikelihood(rbm, v; exact = true)` with `Potts` visible
+  layers erroring on GPU arrays ("illegal conversion to a `Ptr`"): the per-site
+  blocks fed to matrix products are now indexed copies instead of views, since
+  strided views of GPU arrays dispatch `*` to BLAS.
+
 ## 6.1.0
 
 - Removed `logmeanexp`, `logvarexp`, and `logstdexp` (not marked `public`). They

--- a/src/pseudolikelihood.jl
+++ b/src/pseudolikelihood.jl
@@ -231,9 +231,11 @@ function log_pseudolikelihood_exact(rbm::RBM{<:Potts}, v::AbstractArray)
     Inew = similar(Iflat)
     for j in 1:nsites
         rows = ((j - 1) * q + 1):(j * q)
-        Vsite = with_eltype_of(wflat, view(vflat, rows, :)) # q × B, one-hot columns
-        θsite = view(θflat, rows) # q
-        Wsite = view(wflat, rows, :) # q × M
+        # indexed copies, not views: strided views of GPU arrays send `*` to
+        # BLAS, which requires raw pointers
+        Vsite = with_eltype_of(wflat, vflat[rows, :]) # q × B, one-hot columns
+        θsite = θflat[rows] # q
+        Wsite = wflat[rows, :] # q × M
         Wold = Wsite' * Vsite # M × B
         θold = Vsite' * θsite # B
         for x in 1:q
@@ -265,8 +267,10 @@ function log_pseudolikelihood_exact(
 
     for j in 1:nsites
         rows = ((j - 1) * q + 1):(j * q)
-        Vsite = view(vflat, rows, :)
-        Wsite = view(wflat, rows, :)
+        # indexed copies, not views: strided views of GPU arrays send `*` to
+        # BLAS, which requires raw pointers
+        Vsite = vflat[rows, :]
+        Wsite = wflat[rows, :]
         wscaled_site .= Wsite .* reshape(invγ, 1, length(rbm.hidden))
         gram = wscaled_site * Wsite'
         gram_v = gram * Vsite


### PR DESCRIPTION
## Summary

`log_pseudolikelihood(rbm, v; exact = true)` with a `Potts` visible layer errors on GPU arrays with **"Illegal conversion of a JLArray to a Ptr"**. The per-site loops of `log_pseudolikelihood_exact` fed `view`s of the flattened weights/data into matrix products; those views are strided, so LinearAlgebra on Julia 1.12 dispatches `*` to BLAS `gemm!`, which requires raw pointers — illegal for GPU arrays. The GPU generic-matmul hooks are bypassed because the SubArray wrapper satisfies the strided dispatch path.

The failure is deterministic and reproduces on current master (0e090d6) via the `pseudolikelihood` testset of `test/jlarrays.jl`.

**Fix:** materialize the per-site blocks with indexed copies (`wflat[rows, :]` instead of `view(wflat, rows, :)`, etc.) before the matrix products, in both the generic `Potts` path and the `Potts`/`Gaussian` specialization. The copies are `q`-row slices, negligible next to the matmuls they feed. CPU results are the same computation.

Split out of #205 (where CI first surfaced it) so it can be reviewed and merged independently; #205 will be rebased on master once this lands.

## Test plan

- [x] `test/jlarrays.jl` passes on this branch (its `pseudolikelihood` testset fails on master), with `allowscalar(false)`
- [x] Manual JLArrays check of the `Potts`+`Gaussian` exact-pseudolikelihood path (not covered by the testset): matches CPU
- [x] `test/pseudolikelihood.jl` passes (CPU coverage of both modified functions)
- [x] Runic formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK3Q9C91JFmBZxozGJw4wk

---
_Generated by [Claude Code](https://claude.ai/code/session_01NK3Q9C91JFmBZxozGJw4wk)_