### PR TITLE
v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.2.0
 
 - Layer conditional statistics are now organized around moments arrays. The new
   `moments_from_inputs(layer, inputs)` returns per-configuration conditional

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "6.1.1-DEV"
+version = "6.2.0"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Release commit for v6.2.0: drops the `-DEV` suffix from `version` in Project.toml and renames the `## Unreleased` CHANGELOG section to `## 6.2.0`.

Changes since v6.1.0 (see CHANGELOG for details):

- Minimum Julia raised from 1.11 to 1.12 (no CHANGELOG entry, per the decision in #203).
- Moments-based layer statistics API replacing `grad2ave`/`grad2var` (#205).
- Centered `pcd!` trainer updates hidden offsets via `center_hidden_from_data!` with a new `damping` keyword.
- Bug fix: `log_pseudolikelihood(rbm, v; exact = true)` with Potts visible layers no longer errors on GPU arrays (#206).

Minor bump per ColPrac: the Julia compat change is a non-breaking feature; nothing here is breaking (`grad2ave`/`grad2var` were not marked `public`).

After this merges, registration will be triggered by a `@JuliaRegistrator register` comment on the merge commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NK3Q9C91JFmBZxozGJw4wk)_