### PR TITLE
Start next dev cycle: 6.2.1-DEV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
 ## 6.2.0
 
 - Layer conditional statistics are now organized around moments arrays. The new

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "6.2.0"
+version = "6.2.1-DEV"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
v6.2.0 is registered in General ([JuliaRegistries/General#163877](https://github.com/JuliaRegistries/General/pull/163877)) and tagged. This starts the next development cycle, following the release workflow (like #196 last cycle):

- Bump `Project.toml` version to `6.2.1-DEV`.
- Add a fresh empty `## Unreleased` section at the top of CHANGELOG.md.

The `-DEV` number is only a hint — the actual release number is re-derived from the accumulated changes at release time. If you anticipate features this cycle, a minor hint (`6.3.0-DEV`) is available instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NK3Q9C91JFmBZxozGJw4wk)_