### PR TITLE
Define the potential U(h) explicitly in continuous layer docstrings

### DIFF
--- a/docs/src/layers.md
+++ b/docs/src/layers.md
@@ -89,8 +89,8 @@ for positive and negative values of ``x``:
 
 ```math
 U(x) = \begin{cases}
-\frac{\gamma^+}{2} x^2 + \theta^+ x & \text{if } x \geq 0 \\[4pt]
-\frac{\gamma^-}{2} x^2 + \theta^- x & \text{if } x < 0
+\frac{|\gamma^+|}{2} x^2 - \theta^+ x & \text{if } x \geq 0 \\[4pt]
+\frac{|\gamma^-|}{2} x^2 - \theta^- x & \text{if } x < 0
 \end{cases}
 ```
 

--- a/src/layers/drelu.jl
+++ b/src/layers/drelu.jl
@@ -1,7 +1,20 @@
-"""
+@doc raw"""
     dReLU(; θp, θn, γp, γn)
 
 Double ReLU layer, with separate parameters for positive and negative parts.
+The energy of a layer with units ``h_\mu`` is ``E = \sum_\mu U(h_\mu)``, with the
+unit potential:
+
+```math
+U(h) = \begin{cases}
+    \frac{|\gamma^+|}{2} h^2 - \theta^+ h & h \ge 0 \\[4pt]
+    \frac{|\gamma^-|}{2} h^2 - \theta^- h & h < 0
+\end{cases}
+```
+
+where ``\theta^+, \theta^-, \gamma^+, \gamma^-`` are the entries of
+`θp`, `θn`, `γp`, `γn` for the corresponding unit, and ``h`` takes values in
+``\mathbb{R}``.
 """
 @declare_layer dReLU (θp = zeros, θn = zeros, γp = ones, γn = ones)
 

--- a/src/layers/gaussian.jl
+++ b/src/layers/gaussian.jl
@@ -1,7 +1,16 @@
-"""
+@doc raw"""
     Gaussian(θ, γ)
 
 Gaussian layer, with location parameters `θ` and scale parameters `γ`.
+The energy of a layer with units ``h_\mu`` is ``E = \sum_\mu U(h_\mu)``, with the
+unit potential:
+
+```math
+U(h) = \frac{|\gamma|}{2} h^2 - \theta h
+```
+
+where ``\theta``, ``\gamma`` are the entries of `θ`, `γ` for the corresponding
+unit, and ``h`` takes values in ``\mathbb{R}``.
 """
 @declare_layer Gaussian (θ = zeros, γ = ones)
 

--- a/src/layers/nsReLU.jl
+++ b/src/layers/nsReLU.jl
@@ -1,8 +1,21 @@
-"""
-    nsReLU
+@doc raw"""
+    nsReLU(; θ, Δ, ξ)
 
 A variant of `xReLU` units without scale parameter γ (which is fixed at 1). This is done
 to remove the gauge invariance between the weights and the hidden units scale.
+The energy of a layer with units ``h_\mu`` is ``E = \sum_\mu U(h_\mu)``, with the
+unit potential:
+
+```math
+U(h) = \begin{cases}
+    \frac{1}{2(1+\eta)} h^2 - \left(\theta + \frac{\Delta}{1+\eta}\right) h & h \ge 0 \\[4pt]
+    \frac{1}{2(1-\eta)} h^2 - \left(\theta - \frac{\Delta}{1-\eta}\right) h & h < 0
+\end{cases}
+\qquad \eta = \frac{\xi}{1 + |\xi|}
+```
+
+where ``\theta, \Delta, \xi`` are the entries of `θ`, `Δ`, `ξ` for the
+corresponding unit. This is the `xReLU` potential with ``\gamma = 1``.
 """
 @declare_layer nsReLU (θ = zeros, Δ = zeros, ξ = zeros) # there is no γ
 

--- a/src/layers/prelu.jl
+++ b/src/layers/prelu.jl
@@ -1,7 +1,8 @@
 @doc raw"""
     pReLU(; θ, γ, Δ, η)
 
-Parametric ReLU layer, with shared scale and asymmetry ratio.
+A different parameterization of the `dReLU` layer, with shared scale and
+asymmetry ratio.
 The energy of a layer with units ``h_\mu`` is ``E = \sum_\mu U(h_\mu)``, with the
 unit potential:
 

--- a/src/layers/prelu.jl
+++ b/src/layers/prelu.jl
@@ -1,9 +1,24 @@
-"""
+@doc raw"""
     pReLU(; θ, γ, Δ, η)
 
-Parametric ReLU layer, with shared scale and asymmetry ratio. Every value of
-`η` must be finite and lie strictly inside `(-1, 1)`. For unconstrained learned
-asymmetry, use `xReLU` or the fixed-scale `nsReLU` instead.
+Parametric ReLU layer, with shared scale and asymmetry ratio.
+The energy of a layer with units ``h_\mu`` is ``E = \sum_\mu U(h_\mu)``, with the
+unit potential:
+
+```math
+U(h) = \begin{cases}
+    \frac{|\gamma|}{2(1+\eta)} h^2 - \left(\theta + \frac{\Delta}{1+\eta}\right) h & h \ge 0 \\[4pt]
+    \frac{|\gamma|}{2(1-\eta)} h^2 - \left(\theta - \frac{\Delta}{1-\eta}\right) h & h < 0
+\end{cases}
+```
+
+where ``\theta, \gamma, \Delta, \eta`` are the entries of `θ`, `γ`, `Δ`, `η` for
+the corresponding unit. This is the `dReLU` potential with
+``\theta^\pm = \theta \pm \Delta / (1 \pm \eta)`` and
+``\gamma^\pm = \gamma / (1 \pm \eta)``.
+
+Every value of `η` must be finite and lie strictly inside `(-1, 1)`. For
+unconstrained learned asymmetry, use `xReLU` or the fixed-scale `nsReLU` instead.
 """
 @declare_layer pReLU (θ = zeros, γ = ones, Δ = zeros, η = zeros)
 

--- a/src/layers/relu.jl
+++ b/src/layers/relu.jl
@@ -1,7 +1,17 @@
-"""
+@doc raw"""
     ReLU(θ, γ)
 
 Layer with ReLU units, with location parameters `θ` and scale parameters `γ`.
+The energy of a layer with units ``h_\mu`` is ``E = \sum_\mu U(h_\mu)``, with the
+unit potential:
+
+```math
+U(h) = \frac{|\gamma|}{2} h^2 - \theta h \qquad (h \ge 0)
+```
+
+where ``\theta``, ``\gamma`` are the entries of `θ`, `γ` for the corresponding
+unit. Units are constrained to non-negative values (``U(h) = \infty`` for
+``h < 0``).
 """
 @declare_layer ReLU (θ = zeros, γ = ones)
 

--- a/src/layers/xrelu.jl
+++ b/src/layers/xrelu.jl
@@ -1,7 +1,21 @@
-"""
+@doc raw"""
     xReLU(; θ, γ, Δ, ξ)
 
 Extended ReLU layer, like pReLU but with unbounded asymmetry parameter.
+The energy of a layer with units ``h_\mu`` is ``E = \sum_\mu U(h_\mu)``, with the
+unit potential:
+
+```math
+U(h) = \begin{cases}
+    \frac{|\gamma|}{2(1+\eta)} h^2 - \left(\theta + \frac{\Delta}{1+\eta}\right) h & h \ge 0 \\[4pt]
+    \frac{|\gamma|}{2(1-\eta)} h^2 - \left(\theta - \frac{\Delta}{1-\eta}\right) h & h < 0
+\end{cases}
+\qquad \eta = \frac{\xi}{1 + |\xi|}
+```
+
+where ``\theta, \gamma, \Delta, \xi`` are the entries of `θ`, `γ`, `Δ`, `ξ` for
+the corresponding unit. This is the `pReLU` potential with the bounded asymmetry
+``\eta \in (-1, 1)`` reparameterized through the unbounded ``\xi \in \mathbb{R}``.
 """
 @declare_layer xReLU (θ = zeros, γ = ones, Δ = zeros, ξ = zeros)
 


### PR DESCRIPTION
## Summary

- State the unit potential ``U(h)`` explicitly in the docstrings of all continuous layers — `Gaussian`, `ReLU`, `dReLU`, `pReLU`, `xReLU`, and `nsReLU` — following the code convention ``E = \sum_\mu U(h_\mu)``:
  - `Gaussian`: ``U(h) = \frac{|\gamma|}{2} h^2 - \theta h`` over ``h \in \mathbb{R}``.
  - `ReLU`: same potential restricted to ``h \ge 0`` (``U(h) = \infty`` for ``h < 0``).
  - `dReLU`: piecewise potential with separate ``\theta^\pm``, ``\gamma^\pm`` for the positive and negative branches.
  - `pReLU`: piecewise potential written in terms of ``\theta, \gamma, \Delta, \eta``, noting its equivalence to `dReLU` via ``\theta^\pm = \theta \pm \Delta/(1\pm\eta)``, ``\gamma^\pm = \gamma/(1\pm\eta)``.
  - `xReLU`: the `pReLU` potential with ``\eta = \xi/(1+|\xi|)``.
  - `nsReLU`: the `xReLU` potential with ``\gamma = 1``; its docstring header also gains the `nsReLU(; θ, Δ, ξ)` signature line, matching its siblings.
- Fix the dReLU-family potential in `docs/src/layers.md`, which wrote ``+\theta^\pm x`` and omitted the absolute values on ``\gamma^\pm``, contradicting both the implementation (`gauss_energy` uses ``|\gamma| x^2/2 - \theta x``) and the Gaussian/ReLU sections directly above it.

No code behavior changes; converted the touched docstrings to `@doc raw"""` for the LaTeX.

## Verification

- Numerically checked every documented formula against `energies` for all six layers, including negative `γ` values (exercising the ``|\gamma|`` in the formulas), the pReLU→dReLU conversion, xReLU's ``\eta = \xi/(1+|\xi|)`` with negative ``\xi``, and ReLU's infinite potential for ``h &lt; 0``.
- Confirmed the docstrings attach to the macro-generated types and contain the potential.
- `test/layers.jl` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcLgqYKTqQaiHyZouyjLas)_