### PR TITLE
Clarify that the changelog covers only user-observable changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,16 @@ CUDA.jl, and HDF5 persistence. It requires Julia 1.12 or later.
 
 ## Changes and pull requests
 
-- Add `CHANGELOG.md` entries only for user-facing package changes to source,
-  APIs, behavior, or dependencies. Do not add entries for CI, workflows,
-  agent plumbing, or other repository tooling.
+- Add `CHANGELOG.md` entries only for user-facing changes: those a package
+  user would notice through the API defined by the `public` and `export`ed
+  symbols — names, signatures, behavior, results — or through other observable
+  effects such as performance, dependencies, or supported Julia versions. A
+  major internal overhaul may merit a brief entry when its effects reach
+  users. Judge by what a user observes, not by how much code changed:
+  touching `src/` does not by itself warrant an entry. Do not add entries for
+  internal refactors with unchanged observable behavior, test-only changes,
+  docs, formatting, CI, workflows, agent plumbing, or other repository
+  tooling.
 - PRs receive automated review comments from Codex Cloud and the default Claude
   App workflow in `.github/workflows/claude-code-review.yml`. Address each
   actionable finding or explain the disagreement in its thread, reply to every

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -31,8 +31,9 @@ package compute wrong results or break users:
 - Layer parameter storage violations: parameters must live in the single
   `.par` array with named accessors as views; a layer type that stores
   parameters elsewhere breaks HDF5 persistence and gauge transformations.
-- Breaking changes to exported API or behavior not reflected in tests and
-  in the `## Unreleased` section of CHANGELOG.md.
+- Breaking changes to the public API (the `public` and `export`ed symbols)
+  or its behavior not reflected in tests and in the `## Unreleased` section
+  of CHANGELOG.md.
 - Security issues in changes to CI workflows.
 - Substantial avoidable complexity when a materially simpler design satisfies
   the current requirements. Identify the unnecessary structure and a concrete,
@@ -61,8 +62,10 @@ found is a Nit, lead the summary with "No blocking issues."
   agent-docs linter (`.github/scripts/lint_agent_docs.py`).
 - Formatting and code style preferences.
 - Generated files: `Manifest.toml` and built documentation output.
-- Missing CHANGELOG.md entries for CI, workflow, or repo-tooling changes —
-  the changelog records only user-facing package changes.
+- Missing CHANGELOG.md entries for changes with no user-facing effect —
+  CI, workflows, repo tooling, internal refactors, test-only changes. The
+  changelog records only what users observe: the `public`/`export`ed API,
+  its behavior, performance, dependencies, or supported Julia versions.
 
 ## Always check
 
@@ -71,8 +74,8 @@ found is a Nit, lead the summary with "No blocking issues."
   `mode_from_inputs`.
 - New tests do not require a physical GPU (GitHub CI has none); GPU
   compatibility belongs in `test/jlarrays.jl` via JLArrays.
-- Changes to exported functions keep docstrings and tests in sync with the
-  new behavior.
+- Changes to `public`/`export`ed functions keep docstrings and tests in
+  sync with the new behavior.
 - The version in Project.toml keeps its `-DEV` suffix outside of release
   PRs.
 


### PR DESCRIPTION
## Why

CLAUDE.md already restricted the changelog to "user-facing package changes to source, APIs, behavior, or dependencies", but that wording has a loophole: any change to `src/` is a "change to source", and the exclusion list named only CI/workflows/tooling. As a result, implementation-detail entries (internal refactors, test additions, formatting cleanup) kept slipping into `CHANGELOG.md`.

## What changed

**CLAUDE.md** — the changelog bullet now defines *user-facing* explicitly:

- An entry is warranted only for what a package user observes through the API declared by the `public` and `export`ed symbols — names, signatures, behavior, results — or through other observable effects such as performance, dependencies, or supported Julia versions.
- API-neutral changes still qualify when their effects reach users (e.g. a major internal overhaul that changes performance).
- The test is what a user observes, not how much code changed: touching `src/` alone does not warrant an entry. Internal refactors with unchanged observable behavior, test-only changes, docs, formatting, CI, workflows, and repository tooling get none.

**REVIEW.md** — aligned with the same definition:

- "Breaking changes to exported API" now reads "the public API (the `public` and `export`ed symbols)" — the package exports nothing, so the old phrasing named an empty set.
- The do-not-report bullet for missing changelog entries now covers all changes with no user-facing effect (internal refactors and test-only changes, not just CI/tooling).
- The "Always check" docstring/test-sync item likewise says `public`/`export`ed functions.

`.github/scripts/lint_agent_docs.py` passes with no warnings. No `CHANGELOG.md` entry, per the very rule being clarified — this is repository tooling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AePukjqdMhWp4pHyMCHYa1)_