### PR TITLE
Fix moments_from_samples docstring: moments need not match parameter count

### DIFF
--- a/src/layers/abstractlayer.jl
+++ b/src/layers/abstractlayer.jl
@@ -267,8 +267,9 @@ methods); generally they are the sufficient statistics of the layer
 distribution, which do not depend on the layer parameters, so they can be
 computed once from a dataset and reused as the parameters change (see `pcd!`).
 The first axis indexes the moment and the remaining axes are `size(layer)`
-(batch dimensions of `data` are averaged over), so the result has the same
-shape as `layer.par`.
+(batch dimensions of `data` are averaged over). The number of moments need
+not match the number of parameters (e.g. `nsReLU` uses the 4-slot dReLU
+layout while having 3 parameters).
 
 `moments_from_inputs` returns conditional moments in this same layout, and
 `∂energy_from_moments` consumes it.


### PR DESCRIPTION
Follow-up to #214, addressing the automated review finding that arrived just before the merge.

The generic `moments_from_samples` docstring claimed the result "has the same shape as `layer.par`". That is false for `nsReLU`: it has 3 parameters (`θ`, `Δ`, `ξ`; `γ` is fixed at 1) but shares the 4-slot dReLU moments layout — its `∂energy_from_moments` asserts 4 moment rows and drops the `γ` row (`∂[[1, 3, 4], ..]`) to return a 3-row gradient matching `par`.

The docstring now states that the number of moments need not match the number of parameters, with `nsReLU` as the example. Docstring-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf1rQKnfZ7inH8gmpC7bo6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf1rQKnfZ7inH8gmpC7bo6)_