### PR TITLE
Install code-review plugin in the @claude mention workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # write on pull-requests/issues lets Claude post its reply, and lets
+      # `/code-review:code-review --comment` post inline review comments.
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -35,6 +37,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Install the same plugins as claude-code-review.yml so their slash
+          # commands can be invoked by hand from a comment, e.g.
+          #   @claude /code-review:code-review --comment
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Motivation

We have two Claude workflows:

- `claude-code-review.yml` — automatic, runs `/code-review:code-review … --comment` on every push to a non-draft, same-repo PR.
- `claude.yml` — responds to `@claude` mentions in comments, reviews, and issues.

Only the first one registered a plugin marketplace, so plugin slash commands did not exist in the mention workflow. Commenting `@claude /code-review:code-review --comment` on a PR would not have run the structured review — the two workflows had disjoint capabilities.

## Changes

`.github/workflows/claude.yml`:

- Add `plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'` and `plugins: 'code-review@claude-code-plugins'`, matching what `claude-code-review.yml` already installs. This makes `/code-review:code-review` available on demand from a comment.
- Raise `pull-requests` and `issues` from `read` to `write`. Inline review comments are posted with the job's `GITHUB_TOKEN`, so `--comment` cannot write anything under read-only scopes. These are the same permissions `claude-code-review.yml` uses and match the upstream action's documented requirements.

`contents` deliberately stays `read`: this workflow does not push commits, and that is unchanged here. If we later want `@claude fix this` to commit, that needs a separate, deliberate bump to `contents: write`.

## Usage

```
@claude /code-review:code-review --comment
```

The mention gate is untouched — the comment still contains `@claude`, so the existing `if:` condition matches. A bare `@claude <request>` behaves exactly as before; installing a plugin only adds a command, it does not change default behavior.

## Notes

No `CHANGELOG.md` entry: per `CLAUDE.md`, CI and workflow plumbing is not user-facing.

## Testing

- `.github/workflows/claude.yml` parses under `yaml.safe_load`; verified the resulting `permissions` map and the `with:` inputs (`plugin_marketplaces`, `plugins`) are as intended.
- `python3 .github/scripts/lint_agent_docs.py` → OK, 0 warnings.
- Input names `plugins` / `plugin_marketplaces` verified verbatim against `anthropics/claude-code-action@v1`'s `action.yml`; both are optional, newline-separated lists (a single entry per input here, so the plain scalar form is fine).

The end-to-end path can only be exercised on a real PR — worth trying `@claude /code-review:code-review --comment` on this one once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ht8sUxuwXoSaAdZzUGAprP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ht8sUxuwXoSaAdZzUGAprP)_