### PR TITLE
Update testing guidance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,12 +17,10 @@ CUDA.jl, and HDF5 persistence. It requires Julia 1.12 or later.
 - Run the narrowest relevant test file first, then
   `julia --project=. -e 'using Pkg; Pkg.test()'` when the change crosses
   subsystems or affects public behavior.
-- On public repos like this one, do not wait for the full test suite to pass
-  locally before opening a PR. GitHub CI runs the complete suite on every PR
-  at no cost, so focus local runs on a few tests targeting the change and
-  open the PR a bit earlier; let CI provide full coverage. On private repos
-  GitHub CI minutes are limited, so there run the full test suite locally
-  before pushing.
+- Do not wait for the full test suite to pass locally before opening a PR.
+  GitHub CI runs the complete suite on every PR at no cost, so focus local
+  runs on a few tests targeting the change and open the PR a bit earlier;
+  let CI provide full coverage.
 - Load the package with
   `julia --project=. -e 'import RestrictedBoltzmannMachines as RBMs'`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ CUDA.jl, and HDF5 persistence. It requires Julia 1.12 or later.
 - Run the narrowest relevant test file first, then
   `julia --project=. -e 'using Pkg; Pkg.test()'` when the change crosses
   subsystems or affects public behavior.
+- Do not wait for the full test suite to pass locally before opening a PR.
+  GitHub CI runs the complete suite on every PR at no cost, so focus local
+  runs on a few tests targeting the change and open the PR a bit earlier;
+  let CI provide full coverage.
 - Load the package with
   `julia --project=. -e 'import RestrictedBoltzmannMachines as RBMs'`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,12 @@ CUDA.jl, and HDF5 persistence. It requires Julia 1.12 or later.
 - Run the narrowest relevant test file first, then
   `julia --project=. -e 'using Pkg; Pkg.test()'` when the change crosses
   subsystems or affects public behavior.
-- Do not wait for the full test suite to pass locally before opening a PR.
-  GitHub CI runs the complete suite on every PR at no cost, so focus local
-  runs on a few tests targeting the change and open the PR a bit earlier;
-  let CI provide full coverage.
+- On public repos like this one, do not wait for the full test suite to pass
+  locally before opening a PR. GitHub CI runs the complete suite on every PR
+  at no cost, so focus local runs on a few tests targeting the change and
+  open the PR a bit earlier; let CI provide full coverage. On private repos
+  GitHub CI minutes are limited, so there run the full test suite locally
+  before pushing.
 - Load the package with
   `julia --project=. -e 'import RestrictedBoltzmannMachines as RBMs'`.
 


### PR DESCRIPTION
## Summary

Updated the repository workflow documentation in CLAUDE.md to clarify testing practices and encourage earlier PR submission.

## Changes

- Added guidance to not wait for the full test suite to pass locally before opening a PR
- Documented that GitHub CI runs the complete test suite on every PR at no cost
- Recommended focusing local test runs on a few tests targeting the specific change
- Encouraged opening PRs earlier to let CI provide full coverage

## Rationale

This change reflects a pragmatic testing workflow that leverages CI infrastructure efficiently. Rather than requiring developers to run the complete test suite locally (which can be time-consuming), the guidance encourages targeted local testing followed by earlier PR submission, allowing the automated CI pipeline to provide comprehensive coverage. This accelerates the development cycle while maintaining code quality through automated checks.

https://claude.ai/code/session_01Ry2JYQbbmK6LurTcakdRKx