### PR TITLE
Compute pcd! vm/ps/state defaults directly in the keyword signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- The `vm`, `ps`, and `state` keywords of the `pcd!` trainers now compute their
+  defaults directly in the signature instead of using `nothing` as a sentinel.
+  Passing `nothing` explicitly for these keywords is no longer supported; omit
+  the keyword to get the default.
+
 ## 6.2.0
 
 - Layer conditional statistics are now organized around moments arrays. The new

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -271,20 +271,17 @@ function pcd!(
         callback = Returns(nothing), # called for every batch
 
         # init fantasy chains
-        vm = nothing,
+        vm::AbstractArray = _default_fantasy_chains(rbm, batchsize),
 
         shuffle::Bool = true,
 
         # parameters to optimize
-        ps = nothing,
-        state = nothing,
+        ps = (; visible = rbm.visible.par, hidden = rbm.hidden.par, w = rbm.w),
+        state = setup(optim, ps),
     )
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     @assert isnothing(wts) || size(data)[end] == length(wts)
     _validate_layer_parameters(rbm)
-    isnothing(vm) && (vm = _default_fantasy_chains(rbm, batchsize))
-    isnothing(ps) && (ps = (; visible = rbm.visible.par, hidden = rbm.hidden.par, w = rbm.w))
-    isnothing(state) && (state = setup(optim, ps))
 
     data, wts, normalization, batchsize = _prepare_training_data(data, wts; batchsize)
 

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -288,7 +288,7 @@ function pcd!(
         wts::Union{AbstractVector, Nothing} = nothing, # data weights
 
         steps::Int = 1,
-        vm::Union{AbstractArray, Nothing} = nothing,
+        vm::AbstractArray = _default_fantasy_chains(rbm, batchsize),
 
         moments = moments_from_samples(rbm.visible, data; wts), # sufficient statistics for visible layer
 
@@ -307,8 +307,8 @@ function pcd!(
 
         # optimiser
         optim::AbstractRule = Adam(),
-        ps = nothing,
-        state = nothing,
+        ps = (; visible = rbm.visible.par, hidden = rbm.hidden.par, w = rbm.w),
+        state = setup(optim, ps),
 
         # Absorb the scale_h into the hidden unit activation (for hidden units with scale parameter).
         # Results in hidden units with var(h) ~ 1.
@@ -323,9 +323,6 @@ function pcd!(
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     @assert isnothing(wts) || size(data)[end] == length(wts)
     _validate_layer_parameters(rbm)
-    isnothing(vm) && (vm = _default_fantasy_chains(rbm, batchsize))
-    isnothing(ps) && (ps = (; visible = rbm.visible.par, hidden = rbm.hidden.par, w = rbm.w))
-    isnothing(state) && (state = setup(optim, ps))
 
     data, wts, normalization, batchsize = _prepare_training_data(data, wts; batchsize)
 

--- a/src/train/pcd.jl
+++ b/src/train/pcd.jl
@@ -34,13 +34,12 @@ parameters with an `Optimisers.jl` rule.
 - `callback=Returns(nothing)`: called after every update as
   `callback(; rbm, optim, state, ps, iter, vd, wd, ∂, vm)`. Slurp unused
   keywords with a trailing `_...`.
-- `vm=nothing`: initial fantasy particles. By default, these are sampled after
-  validating the model's pReLU parameters.
+- `vm`: initial fantasy particles. By default, `batchsize` chains sampled from
+  the visible layer with zero inputs.
 - `shuffle::Bool=true`: whether to reshuffle samples between epochs.
-- `ps=nothing`: optimized parameter container. By default, this contains the
-  visible, hidden, and interaction parameters.
-- `state=nothing`: optimizer state. By default, this is initialized after
-  validating the model's pReLU parameters.
+- `ps`: optimized parameter container. By default, this contains the visible,
+  hidden, and interaction parameters.
+- `state=setup(optim, ps)`: optimizer state.
 
 Returns `(state, ps)`.
 """
@@ -67,20 +66,17 @@ function pcd!(
         callback = Returns(nothing), # called for every batch
 
         # init fantasy chains
-        vm = nothing,
+        vm::AbstractArray = _default_fantasy_chains(rbm, batchsize),
 
         shuffle::Bool = true,
 
         # parameters to optimize
-        ps = nothing,
-        state = nothing,
+        ps = (; visible = rbm.visible.par, hidden = rbm.hidden.par, w = rbm.w),
+        state = setup(optim, ps),
     )
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     @assert isnothing(wts) || size(data)[end] == length(wts)
     _validate_layer_parameters(rbm)
-    isnothing(vm) && (vm = _default_fantasy_chains(rbm, batchsize))
-    isnothing(ps) && (ps = (; visible = rbm.visible.par, hidden = rbm.hidden.par, w = rbm.w))
-    isnothing(state) && (state = setup(optim, ps))
 
     data, wts, normalization, batchsize = _prepare_training_data(data, wts; batchsize)
 


### PR DESCRIPTION
Replaces the `nothing`-sentinel pattern for the `vm`, `ps`, and `state` keywords of the three `pcd!` trainers (`RBM`, `CenteredRBM`, `StandardizedRBM`) with defaults computed directly in the keyword signature:

```julia
vm::AbstractArray = _default_fantasy_chains(rbm, batchsize),
ps = (; visible = rbm.visible.par, hidden = rbm.hidden.par, w = rbm.w),
state = setup(optim, ps),
```

Julia evaluates keyword defaults left-to-right and later defaults may reference earlier arguments, so this works directly and the three `isnothing(...) && (...)` lines are dropped from each trainer body.

**Why this is safe despite validation ordering.** The old docstring said the `vm` and `state` defaults were created "after validating the model's pReLU parameters," and with defaults in the signature they now evaluate *before* the body's `_validate_layer_parameters(rbm)` call. This doesn't change user-visible behavior: `pReLU` is the only layer with nontrivial validation, and sampling it with out-of-range `η` only propagates NaN/Inf through `drelu_rand`/`randnt` (the rejection sampler returns NaN/Inf without looping or throwing), so the body's validation still raises the same clear `ArgumentError` before any training happens. The only cost is wasted sampling work on that error path. Verified directly: an `RBM` with a `pReLU` visible layer mutated to `η = 2` still throws `ArgumentError` mentioning pReLU from `pcd!`.

**Behavior change.** Passing `vm = nothing`, `ps = nothing`, or `state = nothing` explicitly is no longer supported (previously equivalent to omitting the keyword); omit the keyword to get the default. `vm` is now annotated `::AbstractArray` in all three methods. No caller in the package, tests, or docs passed `nothing` explicitly. Added a brief CHANGELOG entry since `pcd!` is `public`.

**Testing.** `test/pcd.jl` passes, plus a smoke test covering all three trainers with default and explicitly supplied `vm`/`ps`/`state`, and the invalid-pReLU error path. CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPMaRJp8ELpk2KHoHRE6Gd

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPMaRJp8ELpk2KHoHRE6Gd)_