### PR TITLE
v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 7.0.0
 
 - The `vm`, `ps`, and `state` keywords of the `pcd!` trainers now compute their
   defaults directly in the signature instead of using `nothing` as a sentinel.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "7.0.0-DEV"
+version = "7.0.0"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Release v7.0.0: drop the `-DEV` suffix from `version` in Project.toml and rename the `## Unreleased` CHANGELOG section to `## 7.0.0`.

Major bump per ColPrac: the unified weighted code path is breaking for the public API — `wts` must now be an `AbstractVector{<:Real}` and `wts = nothing` is no longer accepted by `pcd!` and `initialize!`; the `vm`, `ps`, and `state` keywords of `pcd!` likewise no longer accept `nothing`. Also includes the switch to `MLUtils.DataLoader` for minibatch iteration (MLUtils becomes a direct dependency) and once-per-run weight validation.

After this merges, registration will be triggered by a Registrator comment on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhS9ZR8hnXo4ps5Dzs3YsV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhS9ZR8hnXo4ps5Dzs3YsV)_