### PR TITLE
Mark training-extension surface as public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file. The format 
   `uniform_weights`), `validate_wts` (renamed from the internal
   `_validate_weights`), `wmean`, `wsum`,
   `rescale_weights!`, `rescale_hidden_activations!`, `center_from_data!`,
-  `center_hidden_from_data!`, `standardize_visible_from_data!`, and
+  `center_visible_from_data!`, `center_hidden_from_data!`,
+  `standardize_visible_from_data!`, and
   `standardize_hidden_from_v!`. The `wts` spelling avoids confusion with the
   RBM weights `w`.
 - `validate_wts` now checks with `@assert` and returns `nothing`, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ All notable changes to this project will be documented in this file. The format 
 
 - Mark the training-extension surface as `public`: `∂free_energy`,
   `∂regularize!`, `sample_from_inputs`, `moments_from_samples`,
-  `infinite_minibatches`, `uniform_weights`, `wmean`, `wsum`,
+  `infinite_minibatches`, `uniform_weights`, `validate_weights` (renamed from
+  the internal `_validate_weights`), `wmean`, `wsum`,
   `rescale_weights!`, `rescale_hidden_activations!`, `center_from_data!`,
   `center_hidden_from_data!`, `standardize_visible_from_data!`, and
   `standardize_hidden_from_v!`.
+- `validate_weights` now checks with `@assert` and returns `nothing`, so
+  invalid training weights raise `AssertionError` (previously `ArgumentError`)
+  from `pcd!` and `initialize!`. The `ArgumentError`s for non-positive
+  `batchsize` and empty data are unchanged.
 
 ## 7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ All notable changes to this project will be documented in this file. The format 
 
 - Mark the training-extension surface as `public`: `∂free_energy`,
   `∂regularize!`, `sample_from_inputs`, `moments_from_samples`,
-  `infinite_minibatches`, `uniform_weights`, `validate_weights` (renamed from
-  the internal `_validate_weights`), `wmean`, `wsum`,
+  `infinite_minibatches`, `uniform_wts` (renamed from the internal
+  `uniform_weights`), `validate_wts` (renamed from the internal
+  `_validate_weights`), `wmean`, `wsum`,
   `rescale_weights!`, `rescale_hidden_activations!`, `center_from_data!`,
   `center_hidden_from_data!`, `standardize_visible_from_data!`, and
-  `standardize_hidden_from_v!`.
-- `validate_weights` now checks with `@assert` and returns `nothing`, so
+  `standardize_hidden_from_v!`. The `wts` spelling avoids confusion with the
+  RBM weights `w`.
+- `validate_wts` now checks with `@assert` and returns `nothing`, so
   invalid training weights raise `AssertionError` (previously `ArgumentError`)
   from `pcd!` and `initialize!`. The `ArgumentError`s for non-positive
   `batchsize` and empty data are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Mark the training-extension surface as `public`: `∂free_energy`,
+  `∂regularize!`, `sample_from_inputs`, `moments_from_samples`,
+  `infinite_minibatches`, `uniform_weights`, `wmean`, `wsum`,
+  `rescale_weights!`, `rescale_hidden_activations!`, `center_from_data!`,
+  `center_hidden_from_data!`, `standardize_visible_from_data!`, and
+  `standardize_hidden_from_v!`.
+
 ## 7.0.0
 
 - The `vm`, `ps`, and `state` keywords of the `pcd!` trainers now compute their

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "7.0.0"
+version = "7.1.0-DEV"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]

--- a/src/RestrictedBoltzmannMachines.jl
+++ b/src/RestrictedBoltzmannMachines.jl
@@ -82,7 +82,7 @@ public cpu, gpu, save_rbm, load_rbm
 public ∂free_energy, ∂regularize!, sample_from_inputs, moments_from_samples
 public infinite_minibatches, uniform_wts, validate_wts, wmean, wsum
 public rescale_weights!, rescale_hidden_activations!
-public center_from_data!, center_hidden_from_data!,
+public center_from_data!, center_visible_from_data!, center_hidden_from_data!,
     standardize_visible_from_data!, standardize_hidden_from_v!
 
 end # module

--- a/src/RestrictedBoltzmannMachines.jl
+++ b/src/RestrictedBoltzmannMachines.jl
@@ -79,5 +79,10 @@ public metropolis, metropolis!, cold_metropolis
 public center, center!, uncenter, standardize, standardize!, unstandardize
 public mirror, zerosum, zerosum!
 public cpu, gpu, save_rbm, load_rbm
+public ∂free_energy, ∂regularize!, sample_from_inputs, moments_from_samples
+public infinite_minibatches, uniform_weights, wmean, wsum
+public rescale_weights!, rescale_hidden_activations!
+public center_from_data!, center_hidden_from_data!,
+    standardize_visible_from_data!, standardize_hidden_from_v!
 
 end # module

--- a/src/RestrictedBoltzmannMachines.jl
+++ b/src/RestrictedBoltzmannMachines.jl
@@ -80,7 +80,7 @@ public center, center!, uncenter, standardize, standardize!, unstandardize
 public mirror, zerosum, zerosum!
 public cpu, gpu, save_rbm, load_rbm
 public ∂free_energy, ∂regularize!, sample_from_inputs, moments_from_samples
-public infinite_minibatches, uniform_weights, validate_weights, wmean, wsum
+public infinite_minibatches, uniform_wts, validate_wts, wmean, wsum
 public rescale_weights!, rescale_hidden_activations!
 public center_from_data!, center_hidden_from_data!,
     standardize_visible_from_data!, standardize_hidden_from_v!

--- a/src/RestrictedBoltzmannMachines.jl
+++ b/src/RestrictedBoltzmannMachines.jl
@@ -80,7 +80,7 @@ public center, center!, uncenter, standardize, standardize!, unstandardize
 public mirror, zerosum, zerosum!
 public cpu, gpu, save_rbm, load_rbm
 public ∂free_energy, ∂regularize!, sample_from_inputs, moments_from_samples
-public infinite_minibatches, uniform_weights, wmean, wsum
+public infinite_minibatches, uniform_weights, validate_weights, wmean, wsum
 public rescale_weights!, rescale_hidden_activations!
 public center_from_data!, center_hidden_from_data!,
     standardize_visible_from_data!, standardize_hidden_from_v!

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -184,6 +184,12 @@ function center_hidden!(rbm::CenteredRBM, offset_h::AbstractArray)
     return rbm
 end
 
+"""
+    center_visible_from_data!(rbm::CenteredRBM, data; [wts])
+
+Sets the visible offsets to the mean of `data`. The model is unchanged (energies
+differ by a constant).
+"""
 function center_visible_from_data!(
         rbm::CenteredRBM, data::AbstractArray;
         wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, data)

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -186,7 +186,7 @@ end
 
 function center_visible_from_data!(
         rbm::CenteredRBM, data::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(rbm.visible, data)
+        wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, data)
     )
     offset_v = batchmean(rbm.visible, data; wts)
     return center_visible!(rbm, offset_v)
@@ -194,7 +194,7 @@ end
 
 function center_hidden_from_data!(
         rbm::CenteredRBM, data::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(rbm.visible, data), damping::Real = 1
+        wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, data), damping::Real = 1
     )
     h = mean_h_from_v(rbm, data)
     offset_h_new = batchmean(rbm.hidden, h; wts)
@@ -204,7 +204,7 @@ end
 
 function center_from_data!(
         rbm::CenteredRBM, data::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(rbm.visible, data)
+        wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, data)
     )
     center_visible_from_data!(rbm, data; wts)
     center_hidden_from_data!(rbm, data; wts)
@@ -259,7 +259,7 @@ function pcd!(
         data::AbstractArray;
         batchsize::Int = 1,
         iters::Int = 1, # number of gradient updates
-        wts::AbstractVector{<:Real} = uniform_weights(rbm.visible, data), # data weights
+        wts::AbstractVector{<:Real} = uniform_wts(rbm.visible, data), # data weights
         steps::Int = 1, # MC steps to update fantasy chains
         optim::AbstractRule = Adam(), # optimizer rule
         moments = moments_from_samples(rbm.visible, data; wts), # sufficient statistics for visible layer
@@ -295,7 +295,7 @@ function pcd!(
         throw(ArgumentError("data must contain at least one sample"))
     length(wts) == size(data, ndims(data)) ||
         throw(DimensionMismatch("length(wts) must equal the number of data samples"))
-    validate_weights(wts)
+    validate_wts(wts)
     wts_mean = mean(wts)
     batchsize = min(batchsize, length(wts))
 

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -295,7 +295,7 @@ function pcd!(
         throw(ArgumentError("data must contain at least one sample"))
     length(wts) == size(data, ndims(data)) ||
         throw(DimensionMismatch("length(wts) must equal the number of data samples"))
-    _validate_weights(wts)
+    validate_weights(wts)
     wts_mean = mean(wts)
     batchsize = min(batchsize, length(wts))
 

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -192,6 +192,14 @@ function center_visible_from_data!(
     return center_visible!(rbm, offset_v)
 end
 
+"""
+    center_hidden_from_data!(rbm::CenteredRBM, data; [wts], damping = 1)
+
+Sets the hidden offsets of `rbm` to the mean hidden unit activations conditioned on
+`data` (interpolated with the current offsets by `damping`, where `damping = 1` takes
+the data estimate in full). The visible fields adapt so the model is equivalent to the
+original one (energies differ by a constant).
+"""
 function center_hidden_from_data!(
         rbm::CenteredRBM, data::AbstractArray;
         wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, data), damping::Real = 1
@@ -202,6 +210,13 @@ function center_hidden_from_data!(
     return center_hidden!(rbm, offset_h)
 end
 
+"""
+    center_from_data!(rbm::CenteredRBM, data; [wts])
+
+Sets the visible offsets of `rbm` to the mean of `data` and the hidden offsets to the
+mean hidden unit activations conditioned on `data`. The fields adapt so the model is
+equivalent to the original one (energies differ by a constant).
+"""
 function center_from_data!(
         rbm::CenteredRBM, data::AbstractArray;
         wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, data)

--- a/src/centered.jl
+++ b/src/centered.jl
@@ -195,10 +195,8 @@ end
 """
     center_hidden_from_data!(rbm::CenteredRBM, data; [wts], damping = 1)
 
-Sets the hidden offsets of `rbm` to the mean hidden unit activations conditioned on
-`data` (interpolated with the current offsets by `damping`, where `damping = 1` takes
-the data estimate in full). The visible fields adapt so the model is equivalent to the
-original one (energies differ by a constant).
+Sets the hidden offsets to the mean hidden activations conditioned on `data`.
+The model is unchanged (energies differ by a constant).
 """
 function center_hidden_from_data!(
         rbm::CenteredRBM, data::AbstractArray;
@@ -213,9 +211,8 @@ end
 """
     center_from_data!(rbm::CenteredRBM, data; [wts])
 
-Sets the visible offsets of `rbm` to the mean of `data` and the hidden offsets to the
-mean hidden unit activations conditioned on `data`. The fields adapt so the model is
-equivalent to the original one (energies differ by a constant).
+Sets the visible and hidden offsets from the means of `data`. The model is unchanged
+(energies differ by a constant).
 """
 function center_from_data!(
         rbm::CenteredRBM, data::AbstractArray;

--- a/src/layers/abstractlayer.jl
+++ b/src/layers/abstractlayer.jl
@@ -164,11 +164,11 @@ function batch_size(layer::AbstractLayer, x::AbstractArray)
 end
 
 """
-    uniform_weights(layer, x)
+    uniform_wts(layer, x)
 
 Lazy uniform weights over the batch dimensions of `x`.
 """
-uniform_weights(layer::AbstractLayer, x::AbstractArray) = Trues(batch_size(layer, x))
+uniform_wts(layer::AbstractLayer, x::AbstractArray) = Trues(batch_size(layer, x))
 
 """
     batchmean(layer, x; [wts])
@@ -176,7 +176,7 @@ uniform_weights(layer::AbstractLayer, x::AbstractArray) = Trues(batch_size(layer
 Mean of `x` over batch dimensions, weigthed by `wts`.
 """
 function batchmean(
-        layer::AbstractLayer, x::AbstractArray; wts::AbstractArray{<:Real} = uniform_weights(layer, x)
+        layer::AbstractLayer, x::AbstractArray; wts::AbstractArray{<:Real} = uniform_wts(layer, x)
     )
     @assert size(wts) == batch_size(layer, x)
     return wmean(x; wts)
@@ -189,7 +189,7 @@ Variance of `x` over batch dimensions, weigthed by `wts`.
 """
 function batchvar(
         layer::AbstractLayer, x::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(layer, x),
+        wts::AbstractArray{<:Real} = uniform_wts(layer, x),
         mean::AbstractArray = batchmean(layer, x; wts)
     )
     return batchmean(layer, (x .- mean) .^ 2; wts)
@@ -202,7 +202,7 @@ Standard deviation of `x` over batch dimensions, weigthed by `wts`.
 """
 function batchstd(
         layer::AbstractLayer, x::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(layer, x),
+        wts::AbstractArray{<:Real} = uniform_wts(layer, x),
         mean::AbstractArray = batchmean(layer, x; wts)
     )
     return sqrt.(batchvar(layer, x; wts, mean))
@@ -215,7 +215,7 @@ Covariance of `x` over batch dimensions, weigthed by `wts`.
 """
 function batchcov(
         layer::AbstractLayer, x::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(layer, x),
+        wts::AbstractArray{<:Real} = uniform_wts(layer, x),
         mean::AbstractArray = batchmean(layer, x; wts)
     )
     @assert size(wts) == batch_size(layer, x)
@@ -231,7 +231,7 @@ Total mean of unit activations from inputs.
 """
 function total_mean_from_inputs(
         layer::AbstractLayer, inputs::AbstractArray = Falses(size(layer));
-        wts::AbstractArray{<:Real} = uniform_weights(layer, inputs)
+        wts::AbstractArray{<:Real} = uniform_wts(layer, inputs)
     )
     h_ave = mean_from_inputs(layer, inputs)
     return batchmean(layer, h_ave; wts)
@@ -244,7 +244,7 @@ Total variance of unit activations from inputs.
 """
 function total_var_from_inputs(
         layer::AbstractLayer, inputs::AbstractArray = Falses(size(layer));
-        wts::AbstractArray{<:Real} = uniform_weights(layer, inputs)
+        wts::AbstractArray{<:Real} = uniform_wts(layer, inputs)
     )
     h_ave, h_var = meanvar_from_inputs(layer, inputs)
     ν_int = batchmean(layer, h_var; wts) # intrinsic noise
@@ -259,7 +259,7 @@ Total mean and total variance of unit activations from inputs.
 """
 function total_meanvar_from_inputs(
         layer::AbstractLayer, inputs::AbstractArray = Falses(size(layer));
-        wts::AbstractArray{<:Real} = uniform_weights(layer, inputs)
+        wts::AbstractArray{<:Real} = uniform_wts(layer, inputs)
     )
     h_ave, h_var = meanvar_from_inputs(layer, inputs)
     μ = batchmean(layer, h_ave; wts)
@@ -306,7 +306,7 @@ Derivative of average energy of `data` with respect to `layer` parameters.
 """
 function ∂energy(
         layer::AbstractLayer, data::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     moments = moments_from_samples(layer, data; wts)
     return ∂energy_from_moments(layer, moments)
@@ -331,7 +331,7 @@ weights by default).
 """
 function batchmean_moments(
         layer::AbstractLayer, moments::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(layer, view(moments, 1, ..))
+        wts::AbstractArray{<:Real} = uniform_wts(layer, view(moments, 1, ..))
     )
     @assert size(wts) == batch_size(layer, view(moments, 1, ..))
     return wmean(moments; wts)
@@ -374,7 +374,7 @@ Averages over configurations (weigthed by `wts`).
 """
 function ∂cgf(
         layer::AbstractLayer, inputs::AbstractArray = Falses(size(layer));
-        wts::AbstractArray{<:Real} = uniform_weights(layer, inputs)
+        wts::AbstractArray{<:Real} = uniform_wts(layer, inputs)
     )
     ∂Fs = ∂cgfs(layer, inputs)
     @assert size(wts) == batch_size(layer, view(∂Fs, 1, ..))

--- a/src/layers/abstractlayer.jl
+++ b/src/layers/abstractlayer.jl
@@ -128,6 +128,13 @@ function cgf(layer::AbstractLayer, inputs::AbstractArray = Falses(size(layer)))
 end
 
 """
+    sample_from_inputs(layer, [inputs])
+
+Samples unit activations of `layer` conditioned on the given inputs.
+"""
+function sample_from_inputs end
+
+"""
     std_from_inputs(layer, [inputs])
 
 Standard deviation of unit activations from inputs.

--- a/src/layers/common.jl
+++ b/src/layers/common.jl
@@ -40,7 +40,7 @@ One moment slot: `<x>`.
 """
 function moments_from_samples(
         layer::_FieldLayers, data::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     x1 = batchmean(layer, data; wts)
     return stack([x1]; dims = 1)
@@ -133,7 +133,7 @@ and `xn = min(x, 0)`.
 """
 function moments_from_samples(
         layer::Union{dReLU, pReLU, xReLU, nsReLU}, data::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     xp = max.(data, false)
     xn = min.(data, false)

--- a/src/layers/gaussian.jl
+++ b/src/layers/gaussian.jl
@@ -59,7 +59,7 @@ Two moment slots: `<x>` and `<x^2>`.
 """
 function moments_from_samples(
         layer::Gaussian, data::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     x1 = batchmean(layer, data; wts)
     x2 = batchmean(layer, data .^ 2; wts)

--- a/src/layers/relu.jl
+++ b/src/layers/relu.jl
@@ -64,7 +64,7 @@ Two moment slots: `<x>` and `<x^2>` (same as `Gaussian`).
 """
 function moments_from_samples(
         layer::ReLU, data::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     return moments_from_samples(Gaussian(layer.par), data; wts)
 end

--- a/src/rbm.jl
+++ b/src/rbm.jl
@@ -344,7 +344,7 @@ end
 Total mean of hidden unit activations from visible activities.
 """
 function total_mean_h_from_v(
-        rbm, v::AbstractArray; wts::AbstractArray{<:Real} = uniform_weights(rbm.visible, v)
+        rbm, v::AbstractArray; wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, v)
     )
     inputs = inputs_h_from_v(rbm, v)
     return total_mean_from_inputs(rbm.hidden, inputs; wts)
@@ -356,7 +356,7 @@ end
 Total mean of visible unit activations from given hidden activities.
 """
 function total_mean_v_from_h(
-        rbm, h::AbstractArray; wts::AbstractArray{<:Real} = uniform_weights(rbm.hidden, h)
+        rbm, h::AbstractArray; wts::AbstractArray{<:Real} = uniform_wts(rbm.hidden, h)
     )
     inputs = inputs_v_from_h(rbm, h)
     return total_mean_from_inputs(rbm.visible, inputs; wts)
@@ -368,7 +368,7 @@ end
 Total variance of hidden unit activations from given visible activities.
 """
 function total_var_h_from_v(
-        rbm, v::AbstractArray; wts::AbstractArray{<:Real} = uniform_weights(rbm.visible, v)
+        rbm, v::AbstractArray; wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, v)
     )
     inputs = inputs_h_from_v(rbm, v)
     return total_var_from_inputs(rbm.hidden, inputs; wts)
@@ -380,7 +380,7 @@ end
 Total variance of unit activations from given hidden activities.
 """
 function total_var_v_from_h(
-        rbm, h::AbstractArray; wts::AbstractArray{<:Real} = uniform_weights(rbm.hidden, h)
+        rbm, h::AbstractArray; wts::AbstractArray{<:Real} = uniform_wts(rbm.hidden, h)
     )
     inputs = inputs_v_from_h(rbm, h)
     return total_var_from_inputs(rbm.visible, inputs; wts)
@@ -392,7 +392,7 @@ end
 Total mean and total variance of hidden unit activations from visible activities.
 """
 function total_meanvar_h_from_v(
-        rbm, v::AbstractArray; wts::AbstractArray{<:Real} = uniform_weights(rbm.visible, v)
+        rbm, v::AbstractArray; wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, v)
     )
     inputs = inputs_h_from_v(rbm, v)
     return total_meanvar_from_inputs(rbm.hidden, inputs; wts)
@@ -404,7 +404,7 @@ end
 Total mean and total variance of visible unit activations from hidden activities.
 """
 function total_meanvar_v_from_h(
-        rbm, h::AbstractArray; wts::AbstractArray{<:Real} = uniform_weights(rbm.hidden, h)
+        rbm, h::AbstractArray; wts::AbstractArray{<:Real} = uniform_wts(rbm.hidden, h)
     )
     inputs = inputs_v_from_h(rbm, h)
     return total_meanvar_from_inputs(rbm.visible, inputs; wts)

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -336,7 +336,7 @@ function pcd!(
         throw(ArgumentError("data must contain at least one sample"))
     length(wts) == size(data, ndims(data)) ||
         throw(DimensionMismatch("length(wts) must equal the number of data samples"))
-    _validate_weights(wts)
+    validate_weights(wts)
     wts_mean = mean(wts)
     batchsize = min(batchsize, length(wts))
 

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -79,10 +79,8 @@ end
 """
     rescale_hidden_activations!(rbm::StandardizedRBM)
 
-For continuous hidden units with a scale parameter, absorbs `scale_h` into the hidden
-layer by dividing hidden unit activations by `scale_h`, leaving unit standardization
-scales (`scale_h .== 1`), and returns `true`. For other hidden units does nothing and
-returns `false`. The modified RBM is equivalent to the original one.
+Absorbs `scale_h` into the hidden layer if it has a scale parameter, returning `true`
+if this was done. The modified RBM is equivalent to the original one.
 """
 function rescale_hidden_activations!(rbm::StandardizedRBM)
     if rescale_activations!(rbm.hidden, rbm.scale_h)
@@ -252,10 +250,8 @@ end
 """
     standardize_visible_from_data!(rbm::StandardizedRBM, data; [wts], ϵ = 0)
 
-Sets the visible offsets and scales of `rbm` to the mean and standard deviation of
-`data` (variances regularized by `ϵ`). Constant coordinates get the neutral unit
-scale. The other parameters adapt so the model is equivalent to the original one
-(energies differ by a constant).
+Sets the visible offsets and scales to the mean and standard deviation of `data`.
+The model is unchanged (energies differ by a constant).
 """
 function standardize_visible_from_data!(
         rbm::StandardizedRBM, data::AbstractArray;
@@ -283,11 +279,8 @@ end
 """
     standardize_hidden_from_v!(rbm::StandardizedRBM, v; [wts], damping = 0, ϵ = 0)
 
-Sets the hidden offsets and scales of `rbm` to the total mean and standard deviation
-of hidden unit activations conditioned on the visible configurations `v` (interpolated
-with the current values by `damping`, where `damping = 1` takes the data estimate in
-full; variances regularized by `ϵ`). The other parameters adapt so the model is
-equivalent to the original one (energies differ by a constant).
+Sets the hidden offsets and scales to the mean and standard deviation of hidden unit
+activations conditioned on `v`. The model is unchanged (energies differ by a constant).
 """
 function standardize_hidden_from_v!(
         rbm::StandardizedRBM, v::AbstractArray;

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -243,7 +243,7 @@ end
 
 function standardize_visible_from_data!(
         rbm::StandardizedRBM, data::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(rbm.visible, data), ϵ::Real = 0
+        wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, data), ϵ::Real = 0
     )
     μ = batchmean(rbm.visible, data; wts)
     ν = batchvar(rbm.visible, data; wts, mean = μ)
@@ -256,7 +256,7 @@ end
 
 function standardize_hidden_from_inputs!(
         rbm::StandardizedRBM, inputs::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(rbm.hidden, inputs), damping::Real = 0, ϵ::Real = 0
+        wts::AbstractArray{<:Real} = uniform_wts(rbm.hidden, inputs), damping::Real = 0, ϵ::Real = 0
     )
     μ, ν = total_meanvar_from_inputs(rbm.hidden, inputs; wts)
     offset_h = (1 - damping) .* rbm.offset_h + damping .* μ
@@ -266,7 +266,7 @@ end
 
 function standardize_hidden_from_v!(
         rbm::StandardizedRBM, v::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(rbm.visible, v), damping::Real = 0, ϵ::Real = 0
+        wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, v), damping::Real = 0, ϵ::Real = 0
     )
     inputs = inputs_h_from_v(rbm, v)
     return standardize_hidden_from_inputs!(rbm, inputs; damping, wts, ϵ)
@@ -294,7 +294,7 @@ function pcd!(
         shuffle::Bool = true,
 
         iters::Int = 1, # number of gradient updates
-        wts::AbstractVector{<:Real} = uniform_weights(rbm.visible, data), # data weights
+        wts::AbstractVector{<:Real} = uniform_wts(rbm.visible, data), # data weights
 
         steps::Int = 1,
         vm::AbstractArray = _default_fantasy_chains(rbm, min(batchsize, size(data)[end])),
@@ -336,7 +336,7 @@ function pcd!(
         throw(ArgumentError("data must contain at least one sample"))
     length(wts) == size(data, ndims(data)) ||
         throw(DimensionMismatch("length(wts) must equal the number of data samples"))
-    validate_weights(wts)
+    validate_wts(wts)
     wts_mean = mean(wts)
     batchsize = min(batchsize, length(wts))
 

--- a/src/standardized.jl
+++ b/src/standardized.jl
@@ -76,6 +76,14 @@ function mirror(rbm::StandardizedRBM)
     return StandardizedRBM(_rbm, rbm.offset_h, rbm.offset_v, rbm.scale_h, rbm.scale_v)
 end
 
+"""
+    rescale_hidden_activations!(rbm::StandardizedRBM)
+
+For continuous hidden units with a scale parameter, absorbs `scale_h` into the hidden
+layer by dividing hidden unit activations by `scale_h`, leaving unit standardization
+scales (`scale_h .== 1`), and returns `true`. For other hidden units does nothing and
+returns `false`. The modified RBM is equivalent to the original one.
+"""
 function rescale_hidden_activations!(rbm::StandardizedRBM)
     if rescale_activations!(rbm.hidden, rbm.scale_h)
         rbm.offset_h ./= rbm.scale_h
@@ -241,6 +249,14 @@ function standardize_hidden!(rbm::StandardizedRBM, offset_h::AbstractArray, scal
     return rbm
 end
 
+"""
+    standardize_visible_from_data!(rbm::StandardizedRBM, data; [wts], ϵ = 0)
+
+Sets the visible offsets and scales of `rbm` to the mean and standard deviation of
+`data` (variances regularized by `ϵ`). Constant coordinates get the neutral unit
+scale. The other parameters adapt so the model is equivalent to the original one
+(energies differ by a constant).
+"""
 function standardize_visible_from_data!(
         rbm::StandardizedRBM, data::AbstractArray;
         wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, data), ϵ::Real = 0
@@ -264,6 +280,15 @@ function standardize_hidden_from_inputs!(
     return standardize_hidden!(rbm, offset_h, scale_h)
 end
 
+"""
+    standardize_hidden_from_v!(rbm::StandardizedRBM, v; [wts], damping = 0, ϵ = 0)
+
+Sets the hidden offsets and scales of `rbm` to the total mean and standard deviation
+of hidden unit activations conditioned on the visible configurations `v` (interpolated
+with the current values by `damping`, where `damping = 1` takes the data estimate in
+full; variances regularized by `ϵ`). The other parameters adapt so the model is
+equivalent to the original one (energies differ by a constant).
+"""
 function standardize_hidden_from_v!(
         rbm::StandardizedRBM, v::AbstractArray;
         wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, v), damping::Real = 0, ϵ::Real = 0

--- a/src/train/gradient.jl
+++ b/src/train/gradient.jl
@@ -23,7 +23,7 @@ Gradient of `free_energy(rbm, v)` with respect to model parameters.
 If `v` consists of multiple samples (batches), then an average is taken.
 """
 function ∂free_energy(
-        rbm, v::AbstractArray; wts::AbstractArray{<:Real} = uniform_weights(rbm.visible, v),
+        rbm, v::AbstractArray; wts::AbstractArray{<:Real} = uniform_wts(rbm.visible, v),
         moments = moments_from_samples(rbm.visible, v; wts)
     )
     inputs = inputs_h_from_v(rbm, v)
@@ -40,7 +40,7 @@ end
 ∂free_energy_v(rbm, v::AbstractArray; kwargs...) = ∂free_energy(rbm, v; kwargs...)
 
 function ∂free_energy_h(
-        rbm, h::AbstractArray; wts::AbstractArray{<:Real} = uniform_weights(rbm.hidden, h),
+        rbm, h::AbstractArray; wts::AbstractArray{<:Real} = uniform_wts(rbm.hidden, h),
         moments = moments_from_samples(rbm.hidden, h; wts)
     )
     inputs = inputs_v_from_h(rbm, h)

--- a/src/train/infinite_minibatches.jl
+++ b/src/train/infinite_minibatches.jl
@@ -15,10 +15,9 @@ observations meant to be excluded must be dropped (with their weights) before
 training. Valid weights are used exactly as given — they are never rescaled
 (extreme finite weights can overflow the plain reductions). Non-real weights
 are rejected by dispatch; lazy uniform weights are trivially valid. =#
-_validate_weights(wts::Ones{<:Real}) = wts
+validate_weights(::Ones{<:Real}) = nothing
 
-function _validate_weights(wts::AbstractArray{<:Real})
-    all(w -> isfinite(w) && w > 0, wts) ||
-        throw(ArgumentError("wts must contain only finite, positive values"))
-    return wts
+function validate_weights(wts::AbstractArray{<:Real})
+    @assert all(w -> isfinite(w) && w > 0, wts) "wts must contain only finite, positive values"
+    return nothing
 end

--- a/src/train/infinite_minibatches.jl
+++ b/src/train/infinite_minibatches.jl
@@ -1,20 +1,28 @@
-#= Minibatch iteration is delegated to MLUtils.DataLoader. `Iterators.cycle`
-restarts the loader whenever an epoch is exhausted, and the loader reshuffles on
-each restart, so the stream is infinite with a fresh permutation per epoch.
-`partial = false` drops the trailing incomplete batch, so every minibatch holds
-exactly `batchsize` observations. A `batchsize` larger than the data clamps to
-one full batch (the training entry point clamps before building the iterator,
-so the loader's clamping warning is not reached from the trainers). =#
+"""
+    infinite_minibatches(ds...; batchsize, shuffle = true)
+
+Infinite iterator over minibatches of exactly `batchsize` observations, drawn from the
+trailing (batch) dimension of each array in `ds`, cycling through the data with a fresh
+shuffle on each pass. The trailing incomplete batch of each pass is dropped. A
+`batchsize` larger than the data clamps to one full batch (the training entry point
+clamps before building the iterator, so the loader's clamping warning is not reached
+from the trainers).
+"""
 function infinite_minibatches(ds::AbstractArray...; batchsize::Int, shuffle::Bool = true)
     batchsize > 0 || throw(ArgumentError("batchsize must be positive"))
     return Iterators.cycle(DataLoader(ds; batchsize, shuffle, partial = false))
 end
 
-#= Weights must be finite, positive reals: zero weights are rejected, so
-observations meant to be excluded must be dropped (with their weights) before
-training. Valid weights are used exactly as given — they are never rescaled
-(extreme finite weights can overflow the plain reductions). Non-real weights
-are rejected by dispatch; lazy uniform weights are trivially valid. =#
+"""
+    validate_wts(wts)
+
+Asserts that the data weights `wts` are finite, positive reals, and returns `nothing`.
+Zero weights are rejected: observations meant to be excluded must be dropped (with
+their weights) before training. Valid weights are used exactly as given by the
+training routines — they are never rescaled (extreme finite weights can overflow the
+plain reductions). Non-real weights are rejected by dispatch; lazy uniform weights are
+trivially valid and skip the check.
+"""
 validate_wts(::Ones{<:Real}) = nothing
 
 function validate_wts(wts::AbstractArray{<:Real})

--- a/src/train/infinite_minibatches.jl
+++ b/src/train/infinite_minibatches.jl
@@ -15,9 +15,9 @@ observations meant to be excluded must be dropped (with their weights) before
 training. Valid weights are used exactly as given — they are never rescaled
 (extreme finite weights can overflow the plain reductions). Non-real weights
 are rejected by dispatch; lazy uniform weights are trivially valid. =#
-validate_weights(::Ones{<:Real}) = nothing
+validate_wts(::Ones{<:Real}) = nothing
 
-function validate_weights(wts::AbstractArray{<:Real})
+function validate_wts(wts::AbstractArray{<:Real})
     @assert all(w -> isfinite(w) && w > 0, wts) "wts must contain only finite, positive values"
     return nothing
 end

--- a/src/train/infinite_minibatches.jl
+++ b/src/train/infinite_minibatches.jl
@@ -1,12 +1,7 @@
 """
     infinite_minibatches(ds...; batchsize, shuffle = true)
 
-Infinite iterator over minibatches of exactly `batchsize` observations, drawn from the
-trailing (batch) dimension of each array in `ds`, cycling through the data with a fresh
-shuffle on each pass. The trailing incomplete batch of each pass is dropped. A
-`batchsize` larger than the data clamps to one full batch (the training entry point
-clamps before building the iterator, so the loader's clamping warning is not reached
-from the trainers).
+Infinite iterator over shuffled minibatches of `batchsize` observations from `ds`.
 """
 function infinite_minibatches(ds::AbstractArray...; batchsize::Int, shuffle::Bool = true)
     batchsize > 0 || throw(ArgumentError("batchsize must be positive"))
@@ -16,12 +11,7 @@ end
 """
     validate_wts(wts)
 
-Asserts that the data weights `wts` are finite, positive reals, and returns `nothing`.
-Zero weights are rejected: observations meant to be excluded must be dropped (with
-their weights) before training. Valid weights are used exactly as given by the
-training routines — they are never rescaled (extreme finite weights can overflow the
-plain reductions). Non-real weights are rejected by dispatch; lazy uniform weights are
-trivially valid and skip the check.
+Asserts that the data weights `wts` are finite and positive.
 """
 validate_wts(::Ones{<:Real}) = nothing
 

--- a/src/train/initialization.jl
+++ b/src/train/initialization.jl
@@ -26,7 +26,7 @@ function initialize!(
     @assert 0 < ϵ < 1 / 2
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     @assert length(wts) == size(data, ndims(data)) > 0
-    _validate_weights(wts)
+    validate_weights(wts)
     initialize!(rbm.visible, data; ϵ, wts)
     initialize!(rbm.hidden)
     initialize_w!(rbm, data; ϵ, wts)
@@ -39,7 +39,7 @@ function initialize!(
         ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_weights(layer, data)
     )
     @assert 0 < ϵ < 1 / 2
-    _validate_weights(wts)
+    validate_weights(wts)
     μ = batchmean(layer, data; wts)
     μϵ = clamp.(μ, ϵ, 1 - ϵ)
     layer.θ .= logit.(μϵ)
@@ -51,7 +51,7 @@ function initialize!(
         ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_weights(layer, data)
     )
     @assert 0 < ϵ < 1 / 2
-    _validate_weights(wts)
+    validate_weights(wts)
     μ = batchmean(layer, data; wts)
     μϵ = clamp.(μ, ϵ - 1, 1 - ϵ)
     layer.θ .= atanh.(μϵ)
@@ -63,7 +63,7 @@ function initialize!(
         ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_weights(layer, data)
     )
     @assert 0 < ϵ < 1 / 2
-    _validate_weights(wts)
+    validate_weights(wts)
     μ = batchmean(layer, data; wts)
     μϵ = clamp.(μ, ϵ, 1 - ϵ)
     layer.θ .= log.(μϵ)
@@ -73,7 +73,7 @@ end
 # Gaussian moment-matching of `θ` and `γ`, shared by the layers initialized as Gaussians.
 function _initialize_gaussian_moments!(θ::AbstractArray, γ::AbstractArray, layer::AbstractLayer, data::AbstractArray; ϵ::Real, wts::AbstractArray{<:Real})
     @assert 0 < ϵ < 1 / 2
-    _validate_weights(wts)
+    validate_weights(wts)
     μ = batchmean(layer, data; wts)
     ν = batchmean(layer, (data .- μ) .^ 2; wts)
     γ .= inv.(ν .+ ϵ)
@@ -150,7 +150,7 @@ function initialize!(
         layer::nsReLU, data::AbstractArray;
         wts::AbstractArray{<:Real} = uniform_weights(layer, data)
     )
-    _validate_weights(wts)
+    validate_weights(wts)
     μ = batchmean(layer, data; wts)
     layer.θ .= μ
     layer.Δ .= layer.ξ .= 0
@@ -173,7 +173,7 @@ function initialize_w!(
     )
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     @assert length(wts) == size(data)[end]
-    _validate_weights(wts)
+    validate_weights(wts)
     x = reshape(data, length(rbm.visible), size(data)[end])
     d = dot(x .* reshape(wts, 1, :), x / sum(wts))
     randn!(rbm.w)

--- a/src/train/initialization.jl
+++ b/src/train/initialization.jl
@@ -21,12 +21,12 @@ end
 
 function initialize!(
         rbm::RBM, data::AbstractArray;
-        ϵ::Real = 1.0e-6, wts::AbstractVector{<:Real} = uniform_weights(rbm.visible, data)
+        ϵ::Real = 1.0e-6, wts::AbstractVector{<:Real} = uniform_wts(rbm.visible, data)
     )
     @assert 0 < ϵ < 1 / 2
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     @assert length(wts) == size(data, ndims(data)) > 0
-    validate_weights(wts)
+    validate_wts(wts)
     initialize!(rbm.visible, data; ϵ, wts)
     initialize!(rbm.hidden)
     initialize_w!(rbm, data; ϵ, wts)
@@ -36,10 +36,10 @@ end
 
 function initialize!(
         layer::Binary, data::AbstractArray;
-        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     @assert 0 < ϵ < 1 / 2
-    validate_weights(wts)
+    validate_wts(wts)
     μ = batchmean(layer, data; wts)
     μϵ = clamp.(μ, ϵ, 1 - ϵ)
     layer.θ .= logit.(μϵ)
@@ -48,10 +48,10 @@ end
 
 function initialize!(
         layer::Spin, data::AbstractArray;
-        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     @assert 0 < ϵ < 1 / 2
-    validate_weights(wts)
+    validate_wts(wts)
     μ = batchmean(layer, data; wts)
     μϵ = clamp.(μ, ϵ - 1, 1 - ϵ)
     layer.θ .= atanh.(μϵ)
@@ -60,10 +60,10 @@ end
 
 function initialize!(
         layer::Union{Potts, PottsGumbel}, data::AbstractArray;
-        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     @assert 0 < ϵ < 1 / 2
-    validate_weights(wts)
+    validate_wts(wts)
     μ = batchmean(layer, data; wts)
     μϵ = clamp.(μ, ϵ, 1 - ϵ)
     layer.θ .= log.(μϵ)
@@ -73,7 +73,7 @@ end
 # Gaussian moment-matching of `θ` and `γ`, shared by the layers initialized as Gaussians.
 function _initialize_gaussian_moments!(θ::AbstractArray, γ::AbstractArray, layer::AbstractLayer, data::AbstractArray; ϵ::Real, wts::AbstractArray{<:Real})
     @assert 0 < ϵ < 1 / 2
-    validate_weights(wts)
+    validate_wts(wts)
     μ = batchmean(layer, data; wts)
     ν = batchmean(layer, (data .- μ) .^ 2; wts)
     γ .= inv.(ν .+ ϵ)
@@ -83,14 +83,14 @@ end
 
 function initialize!(
         layer::Gaussian, data::AbstractArray;
-        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     return _initialize_gaussian_moments!(layer.θ, layer.γ, layer, data; ϵ, wts)
 end
 
 function initialize!(
         layer::xReLU, data::AbstractArray;
-        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     _initialize_gaussian_moments!(layer.θ, layer.γ, layer, data; ϵ, wts)
     layer.Δ .= layer.ξ .= 0
@@ -99,7 +99,7 @@ end
 
 function initialize!(
         layer::pReLU, data::AbstractArray;
-        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     _initialize_gaussian_moments!(layer.θ, layer.γ, layer, data; ϵ, wts)
     layer.Δ .= layer.η .= 0
@@ -108,7 +108,7 @@ end
 
 function initialize!(
         layer::dReLU, data::AbstractArray;
-        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        ϵ::Real = 1.0e-6, wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
     # initialize as Gaussian
     _initialize_gaussian_moments!(layer.θp, layer.γp, layer, data; ϵ, wts)
@@ -148,9 +148,9 @@ end
 
 function initialize!(
         layer::nsReLU, data::AbstractArray;
-        wts::AbstractArray{<:Real} = uniform_weights(layer, data)
+        wts::AbstractArray{<:Real} = uniform_wts(layer, data)
     )
-    validate_weights(wts)
+    validate_wts(wts)
     μ = batchmean(layer, data; wts)
     layer.θ .= μ
     layer.Δ .= layer.ξ .= 0
@@ -169,11 +169,11 @@ Initializes `rbm.w` such that typical inputs to hidden units are λ.
 """
 function initialize_w!(
         rbm::RBM, data::AbstractArray;
-        λ::Real = 0.1, ϵ::Real = 1.0e-6, wts::AbstractVector{<:Real} = uniform_weights(rbm.visible, data)
+        λ::Real = 0.1, ϵ::Real = 1.0e-6, wts::AbstractVector{<:Real} = uniform_wts(rbm.visible, data)
     )
     @assert size(data) == (size(rbm.visible)..., size(data)[end])
     @assert length(wts) == size(data)[end]
-    validate_weights(wts)
+    validate_wts(wts)
     x = reshape(data, length(rbm.visible), size(data)[end])
     d = dot(x .* reshape(wts, 1, :), x / sum(wts))
     randn!(rbm.w)

--- a/src/train/pcd.jl
+++ b/src/train/pcd.jl
@@ -49,7 +49,7 @@ function pcd!(
         data::AbstractArray;
         batchsize::Int = 1,
         iters::Int = 1, # number of gradient updates
-        wts::AbstractVector{<:Real} = uniform_weights(rbm.visible, data), # data weights
+        wts::AbstractVector{<:Real} = uniform_wts(rbm.visible, data), # data weights
         steps::Int = 1, # MC steps to update fantasy chains
         optim::AbstractRule = Adam(), # optimizer rule
         moments = moments_from_samples(rbm.visible, data; wts), # sufficient statistics for visible layer
@@ -82,7 +82,7 @@ function pcd!(
         throw(ArgumentError("data must contain at least one sample"))
     length(wts) == size(data, ndims(data)) ||
         throw(DimensionMismatch("length(wts) must equal the number of data samples"))
-    validate_weights(wts)
+    validate_wts(wts)
     wts_mean = mean(wts)
     batchsize = min(batchsize, length(wts))
 

--- a/src/train/pcd.jl
+++ b/src/train/pcd.jl
@@ -82,7 +82,7 @@ function pcd!(
         throw(ArgumentError("data must contain at least one sample"))
     length(wts) == size(data, ndims(data)) ||
         throw(DimensionMismatch("length(wts) must equal the number of data samples"))
-    _validate_weights(wts)
+    validate_weights(wts)
     wts_mean = mean(wts)
     batchsize = min(batchsize, length(wts))
 

--- a/test/zero_weight_training.jl
+++ b/test/zero_weight_training.jl
@@ -63,10 +63,10 @@ all_finite(rbm) = all(x -> all(isfinite, x), values(model_state(rbm)))
             [1.0, NaN],
             [1.0, Inf],
         )
-        @test_throws ArgumentError RBMs._validate_weights(bad_wts)
+        @test_throws AssertionError RBMs.validate_weights(bad_wts)
         rbm = base_rbm()
         before = model_state(rbm)
-        @test_throws ArgumentError pcd!(
+        @test_throws AssertionError pcd!(
             rbm, data;
             wts = bad_wts, batchsize = 1, iters = 0,
             zerosum = false, rescale = false,
@@ -75,7 +75,7 @@ all_finite(rbm) = all(x -> all(isfinite, x), values(model_state(rbm)))
     end
     # non-real weights are rejected by the signatures (TypeError for the
     # keyword annotation, MethodError for positional dispatch)
-    @test_throws MethodError RBMs._validate_weights(ComplexF64[1, 1])
+    @test_throws MethodError RBMs.validate_weights(ComplexF64[1, 1])
     @test_throws TypeError pcd!(
         base_rbm(), data;
         wts = ComplexF64[1, 1], batchsize = 1, iters = 0,
@@ -110,8 +110,8 @@ end
 
 @testset "training weight checks" begin
     # lazy uniform weights must still be real-valued to skip validation
-    @test RBMs._validate_weights(Trues(3)) isa Ones
-    @test_throws MethodError RBMs._validate_weights(Ones{ComplexF64}(2))
+    @test RBMs.validate_weights(Trues(3)) === nothing
+    @test_throws MethodError RBMs.validate_weights(Ones{ComplexF64}(2))
 
     # Empty data and undersized weights are rejected before mutation. The
     # default `moments` kwarg already fails computing statistics of such
@@ -175,13 +175,13 @@ end
     @test model_state(scaled_rbm) == model_state(unit_rbm)
 
     # invalid weights fail loudly
-    @test_throws ArgumentError initialize!(base_rbm(), data; wts = [1.0, -1.0, 1.0])
-    @test_throws ArgumentError initialize!(base_rbm(), data; wts = [1.0, 0.0, 1.0])
-    @test_throws ArgumentError initialize!(base_rbm(), data; wts = [1.0, NaN, 1.0])
+    @test_throws AssertionError initialize!(base_rbm(), data; wts = [1.0, -1.0, 1.0])
+    @test_throws AssertionError initialize!(base_rbm(), data; wts = [1.0, 0.0, 1.0])
+    @test_throws AssertionError initialize!(base_rbm(), data; wts = [1.0, NaN, 1.0])
     # ... also at the per-layer and initialize_w! entry points
-    @test_throws ArgumentError initialize!(RBMs.Binary((2,)), data; wts = [1.0, 0.0, 1.0])
-    @test_throws ArgumentError initialize!(RBMs.Gaussian((2,)), data; wts = [1.0, -1.0, 1.0])
-    @test_throws ArgumentError RBMs.initialize_w!(base_rbm(), data; wts = [1.0, NaN, 1.0])
+    @test_throws AssertionError initialize!(RBMs.Binary((2,)), data; wts = [1.0, 0.0, 1.0])
+    @test_throws AssertionError initialize!(RBMs.Gaussian((2,)), data; wts = [1.0, -1.0, 1.0])
+    @test_throws AssertionError RBMs.initialize_w!(base_rbm(), data; wts = [1.0, NaN, 1.0])
     # undersized weights are rejected instead of silently truncating the data
     @test_throws AssertionError initialize!(base_rbm(), data; wts = [1.0, 1.0])
 
@@ -236,7 +236,7 @@ function check_all_zero_pcd(kind)
     updates = Ref(0)
     callbacks = Ref(0)
 
-    @test_throws ArgumentError pcd!(
+    @test_throws AssertionError pcd!(
         rbm, data;
         wts, batchsize = 2, iters = 1, steps = 1,
         optim = CountingDescent(0.01, updates),

--- a/test/zero_weight_training.jl
+++ b/test/zero_weight_training.jl
@@ -63,7 +63,7 @@ all_finite(rbm) = all(x -> all(isfinite, x), values(model_state(rbm)))
             [1.0, NaN],
             [1.0, Inf],
         )
-        @test_throws AssertionError RBMs.validate_weights(bad_wts)
+        @test_throws AssertionError RBMs.validate_wts(bad_wts)
         rbm = base_rbm()
         before = model_state(rbm)
         @test_throws AssertionError pcd!(
@@ -75,7 +75,7 @@ all_finite(rbm) = all(x -> all(isfinite, x), values(model_state(rbm)))
     end
     # non-real weights are rejected by the signatures (TypeError for the
     # keyword annotation, MethodError for positional dispatch)
-    @test_throws MethodError RBMs.validate_weights(ComplexF64[1, 1])
+    @test_throws MethodError RBMs.validate_wts(ComplexF64[1, 1])
     @test_throws TypeError pcd!(
         base_rbm(), data;
         wts = ComplexF64[1, 1], batchsize = 1, iters = 0,
@@ -110,8 +110,8 @@ end
 
 @testset "training weight checks" begin
     # lazy uniform weights must still be real-valued to skip validation
-    @test RBMs.validate_weights(Trues(3)) === nothing
-    @test_throws MethodError RBMs.validate_weights(Ones{ComplexF64}(2))
+    @test RBMs.validate_wts(Trues(3)) === nothing
+    @test_throws MethodError RBMs.validate_wts(Ones{ComplexF64}(2))
 
     # Empty data and undersized weights are rejected before mutation. The
     # default `moments` kwarg already fails computing statistics of such


### PR DESCRIPTION
Adds `public` declarations in the main module for the symbols downstream packages need to extend or drive training:

- Gradient / regularization: `∂free_energy`, `∂regularize!`
- Layer statistics and sampling: `sample_from_inputs`, `moments_from_samples`
- Training utilities: `infinite_minibatches`, `uniform_wts`, `validate_wts`, `wmean`, `wsum`
- Gauge / rescaling: `rescale_weights!`, `rescale_hidden_activations!`
- Centering / standardization from data: `center_from_data!`, `center_visible_from_data!`, `center_hidden_from_data!`, `standardize_visible_from_data!`, `standardize_hidden_from_v!`

Additional changes:

- The data-weight helpers are renamed as part of making them public, using the `wts` spelling to avoid confusion with the RBM weights `w`: `uniform_weights` → `uniform_wts` and `_validate_weights` → `validate_wts`.
- `validate_wts` now checks with `@assert` and returns `nothing`, so invalid training weights raise `AssertionError` (previously `ArgumentError`) from `pcd!` and `initialize!`; the `ArgumentError`s for non-positive `batchsize` and empty data are unchanged. Tests updated accordingly.
- All newly public functions have docstrings (per review), kept to the repo's terse style.
- Version bumped to `7.1.0-DEV`; changelog entries added under `## Unreleased`.

All 16 public names were verified to be defined, documented, and reported public by `Base.ispublic` after loading the package, and `test/zero_weight_training.jl` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GST2M9nixzUSLGBgiQowid