### PR TITLE
Split CI test suite into 4 parallel groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - group ${{ matrix.group }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -19,6 +19,12 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
+        # Test groups defined in test/runtests.jl, run as parallel jobs.
+        group:
+          - '1'
+          - '2'
+          - '3'
+          - '4'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32
@@ -30,6 +36,8 @@ jobs:
       - uses: julia-actions/julia-runtest@6e050c8013b833b1195105ff2fce9cd802f53271
         with:
           coverage: true
+        env:
+          RBM_TEST_GROUP: ${{ matrix.group }}
       - uses: julia-actions/julia-processcoverage@03114f09f119417c3242a9fb6e0b722676aedf38
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
@@ -39,8 +47,17 @@ jobs:
           # Fork PRs can't access secrets, so their uploads stay best-effort.
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
   downgrade:
-    name: Downgrade compat - Julia min - ubuntu-latest - x64
+    name: Downgrade compat - Julia min - ubuntu-latest - x64 - group ${{ matrix.group }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test groups defined in test/runtests.jl, run as parallel jobs.
+        group:
+          - '1'
+          - '2'
+          - '3'
+          - '4'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32
@@ -57,3 +74,5 @@ jobs:
         with:
           allow_reresolve: false
           force_latest_compatible_version: false
+        env:
+          RBM_TEST_GROUP: ${{ matrix.group }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,14 @@
+codecov:
+  notify:
+    # CI runs the test suite as 4 parallel group jobs (see test/runtests.jl),
+    # each uploading its own coverage report. Wait for all of them before
+    # computing status, so a partial merge doesn't report a spurious drop.
+    after_n_builds: 4
+    wait_for_ci: true
+
+comment:
+  after_n_builds: 4
+
 coverage:
   status:
     # Overall repository coverage: must not drop by more than 1% in a PR.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,6 @@ for file in test_files
     name = Symbol(replace(file, r"\.jl$" => "", "/" => "_"), :_tests)
     path = joinpath(@__DIR__, file)
     @eval module $name
-        include($path)
+    include($path)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,87 +1,55 @@
-module util_tests
-    include("util.jl")
-end
-module onehot_tests
-    include("onehot.jl")
-end
-module rbm_tests
-    include("rbm.jl")
-end
-module layers_tests
-    include("layers.jl")
-end
-module prelu_validation_tests
-    include("prelu_validation.jl")
-end
-module pseudolikelihood_tests
-    include("pseudolikelihood.jl")
-end
-module infinite_minibatches_tests
-    include("infinite_minibatches.jl")
-end
-module initialization_tests
-    include("initialization.jl")
-end
-module regularize_tests
-    include("regularize.jl")
-end
-module truncnorm_tests
-    include("truncnorm.jl")
-end
-module optim_tests
-    include("optim.jl")
-end
-module partition_tests
-    include("partition.jl")
-end
-module metropolis_tests
-    include("metropolis.jl")
-end
-module sampling_stationarity_tests
-    include("sampling_stationarity.jl")
-end
-module zerosum_tests
-    include("gauge/zerosum.jl")
-end
-module rescale_hidden_tests
-    include("gauge/rescale_hidden.jl")
-end
-module pcd_tests
-    include("pcd.jl")
-end
-module zero_weight_training_tests
-    include("zero_weight_training.jl")
-end
-module train_tests
-    include("train.jl")
-end
-module shift_fields_tests
-    include("shift_fields.jl")
-end
-module pottsgumbel_tests
-    include("pottsgumbel.jl")
-end
-module explicit_imports_tests
-    include("explicit_imports.jl")
-end
-module hdf5_tests
-    include("hdf5.jl")
-end
-module centered_tests
-    include("centered.jl")
-end
-module standardized_tests
-    include("standardized.jl")
-end
-module nsReLU_tests
-    include("layers/nsReLU.jl")
-end
-module ais_tests
-    include("ais.jl")
-end
-module jlarrays_tests
-    include("jlarrays.jl")
-end
-module aqua_tests
-    include("aqua.jl")
+# Test files are independent modules. GitHub CI splits them into the groups
+# below and runs each group as a separate parallel job. Keep the groups
+# roughly balanced in runtime (see timings in .github/workflows/ci.yml runs).
+# Set RBM_TEST_GROUP=1..4 to run a single group; leave it unset (or set it to
+# "all") to run the full suite, as a plain `Pkg.test()` does.
+const TEST_GROUPS = (
+    [ # group 1
+        "layers.jl",
+        "prelu_validation.jl",
+        "truncnorm.jl",
+        "optim.jl",
+        "layers/nsReLU.jl",
+    ],
+    [ # group 2
+        "util.jl",
+        "onehot.jl",
+        "rbm.jl",
+        "shift_fields.jl",
+        "standardized.jl",
+    ],
+    [ # group 3
+        "gauge/zerosum.jl",
+        "pottsgumbel.jl",
+        "centered.jl",
+        "jlarrays.jl",
+    ],
+    [ # group 4
+        "pseudolikelihood.jl",
+        "infinite_minibatches.jl",
+        "initialization.jl",
+        "regularize.jl",
+        "partition.jl",
+        "metropolis.jl",
+        "sampling_stationarity.jl",
+        "gauge/rescale_hidden.jl",
+        "pcd.jl",
+        "zero_weight_training.jl",
+        "train.jl",
+        "explicit_imports.jl",
+        "hdf5.jl",
+        "ais.jl",
+        "aqua.jl",
+    ],
+)
+
+group = get(ENV, "RBM_TEST_GROUP", "all")
+test_files = group == "all" ? reduce(vcat, TEST_GROUPS) : TEST_GROUPS[parse(Int, group)]
+
+for file in test_files
+    name = Symbol(replace(file, r"\.jl$" => "", "/" => "_"), :_tests)
+    path = joinpath(@__DIR__, file)
+    @eval module $name
+        include($path)
+    end
 end


### PR DESCRIPTION
## Motivation

CI wall time was ~23 minutes, dominated by the ~21-minute serial test run that both the `test` job and the `downgrade` job execute in full. The test files in `test/runtests.jl` are already independent modules, so they can run as parallel CI jobs.

## Changes

- `test/runtests.jl`: the test files are now organized into 4 groups, balanced using per-file wall-time measured from a recent CI run on `master` (heaviest files: `layers.jl` ~4.7 min, `jlarrays.jl` ~2.6 min, `rbm.jl` ~2.3 min, `standardized.jl` ~2.2 min). A new `RBM_TEST_GROUP` environment variable selects a single group; when unset (or `all`), the full suite runs, so a plain local `Pkg.test()` behaves exactly as before. Modules are generated from the file lists with `@eval`, replacing the hand-written module-per-file boilerplate; the same 29 files are included either way.
- `.github/workflows/ci.yml`: both the `test` and `downgrade` jobs gain a `group: ['1'..'4']` matrix dimension and pass `RBM_TEST_GROUP` to `julia-runtest`.
- `codecov.yml`: with 4 coverage uploads per commit, Codecov now waits for all of them (`after_n_builds: 4`) before computing status or commenting, so a partial merge doesn't report a spurious coverage drop.

**Observed result:** the full matrix (8 jobs) completes in ~12 minutes of wall time, versus ~23 minutes before — see [this run](https://github.com/cossio/RestrictedBoltzmannMachines.jl/actions/runs/31384513621).

## Notes

- Job names change (e.g. `Julia 1 - ubuntu-latest - x64` → `Julia 1 - ubuntu-latest - x64 - group 1`). If branch protection lists the old job names as required status checks, that list needs updating after this merges.
- The first two runs hit a transient Aqua `Persistent tasks` failure in the downgrade group-4 job: Aqua's wrapper-precompile subprocess (which inherits `--check-bounds=yes --code-coverage` and therefore recompiles every dependency from scratch) died on runners with cold per-group caches. It passed once the group's cache was warm, and the wrapper environment resolves and precompiles cleanly when reproduced locally with min-pinned deps.
- No CHANGELOG entry since this is CI/test tooling with no user-facing effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YE1r2xKfPNfpoyQ3Z3JKtw