### PR TITLE
v7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 7.1.0
 
 - Mark the training-extension surface as `public`: `∂free_energy`,
   `∂regularize!`, `sample_from_inputs`, `moments_from_samples`,

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "7.1.0-DEV"
+version = "7.1.0"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Release commit for v7.1.0: drops the `-DEV` suffix in `Project.toml` and renames the `## Unreleased` CHANGELOG section to `## 7.1.0`.

Changes in this release (from the CHANGELOG):

- Mark the training-extension surface as `public` (16 names, all with docstrings), with the data-weight helpers renamed to the `wts` spelling: `uniform_weights` → `uniform_wts`, `_validate_weights` → `validate_wts`.
- `validate_wts` now checks with `@assert` and returns `nothing`, so invalid training weights raise `AssertionError` (previously `ArgumentError`) from `pcd!` and `initialize!`.

Minor bump per ColPrac: non-breaking features (new public API); the renamed helpers were not in the 7.0.0 `public` block.

After this merges, registration will be triggered by a Registrator comment on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GST2M9nixzUSLGBgiQowid

---
_Generated by [Claude Code](https://claude.ai/code/session_01GST2M9nixzUSLGBgiQowid)_