### PR TITLE
Bump version to 7.1.1-DEV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
 ## 7.1.0
 
 - Mark the training-extension surface as `public`: `∂free_energy`,

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RestrictedBoltzmannMachines"
 uuid = "12e6b396-7db5-4506-8cb6-664a4fe1e50e"
 authors = ["Jorge FdCD <jorge.fdcd@icloud.com>"]
-version = "7.1.0"
+version = "7.1.1-DEV"
 
 [workspace]
 projects = ["test", "docs", "notebooks", "repl"]


### PR DESCRIPTION
Starts the next development cycle after the v7.1.0 release (registered in General via [JuliaRegistries/General#164046](https://github.com/JuliaRegistries/General/pull/164046)): bumps `Project.toml` to `7.1.1-DEV` and adds a fresh empty `## Unreleased` section at the top of `CHANGELOG.md`.

The `-DEV` number is only a hint — the actual release number is re-derived from the accumulated changes at release time. If you anticipate features landing next, a `7.2.0-DEV` hint is available instead; say the word and I'll update it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GST2M9nixzUSLGBgiQowid

---
_Generated by [Claude Code](https://claude.ai/code/session_01GST2M9nixzUSLGBgiQowid)_