### PR TITLE
Prewarm Aqua persistent-tasks env to dodge precompile race

### DIFF
--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -2,6 +2,31 @@ import Aqua
 import RestrictedBoltzmannMachines
 using Test: @testset
 
+# Work around a Julia 1.12 parallel-precompilation race (extension build-id
+# invalidation, e.g. LogExpFunctionsChainRulesCoreExt) that makes the wrapper
+# package in Aqua.test_persistent_tasks fail to precompile softly whenever its
+# freshly-resolved dependency graph is cold: Pkg files the wrapper under
+# "failed but may be precompilable after restarting julia" and exits 0, so
+# Aqua's done.log sentinel never appears. Precompiling an equivalent
+# environment once beforehand absorbs the race, so Aqua's wrapper compiles
+# against warm caches. No-op when caches are already warm.
+function prewarm_persistent_tasks_env(pkg::Module)
+    dir = mktempdir()
+    code = """
+    push!(LOAD_PATH, "@stdlib")
+    using Pkg
+    Pkg.activate($(repr(dir)); io = devnull)
+    Pkg.develop(Pkg.PackageSpec(path = $(repr(pkgdir(pkg)))); io = devnull)
+    Pkg.precompile()
+    """
+    for _ in 1:2
+        success(`$(Base.julia_cmd()) --startup-file=no -e $code`) && break
+    end
+    return nothing
+end
+
+prewarm_persistent_tasks_env(RestrictedBoltzmannMachines)
+
 @testset "aqua" begin
     Aqua.test_all(
         RestrictedBoltzmannMachines;


### PR DESCRIPTION
Follow-up to the "Downgrade compat" CI failures on [#235](https://github.com/cossio/RestrictedBoltzmannMachines.jl/pull/235) (root-caused there in [this comment](https://github.com/cossio/RestrictedBoltzmannMachines.jl/pull/235#issuecomment-5458224183) and the session investigation).

## Problem

`Aqua.test_persistent_tasks` generates a throwaway wrapper package that `Pkg.develop`s this package and resolves its dependencies **fresh from the registry** (latest versions — independent of the job's manifest). When that graph is cold — e.g. right after a dependency release invalidates CI's depot cache, as NNlib 0.9.45 did on 2026-08-28 — Julia 1.12's parallel precompilation races the wrapper package against extension rebuilds (`LogExpFunctionsChainRulesCoreExt`): the wrapper's precompile aborts with "Module ... is missing from the cache", Pkg files it under "1 dependency failed but may be precompilable after restarting julia", and `Pkg.precompile()` **exits 0**. Aqua runs it with `io = devnull`, sees no `done.log` sentinel, and fails with only:

```
Error: Unexpected error: /tmp/jl_.../done.log was not created, but precompilation exited
```

Each failed attempt still compiles the dependency graph and saves the depot cache, which is why a plain re-run goes green (as #235's third attempt did) — and why the failure will recur on any branch after the next wrapper-graph dependency release.

## Fix

Before `Aqua.test_all`, precompile an equivalent environment (temp project + `Pkg.develop` of this package) in a subprocess, retrying once. This absorbs the race, so Aqua's wrapper always compiles against warm caches. It skips nothing — the persistent-tasks check still runs in full — and is a fast no-op when caches are already warm.

Verified against a deterministic local reproduction on Julia 1.12.7 (wiping `~/.julia/compiled/v1.12` and running `Pkg.test(coverage = true)` with `--check-bounds=yes`): fails 3/3 without the patch, passes with it.

No CHANGELOG entry: test-only change. The underlying issues belong upstream (Aqua: exit-code/diagnostics handling in `test_persistent_tasks`; Julia: the extension precompile race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpiKWyR18iV7w3qhsRLBgz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpiKWyR18iV7w3qhsRLBgz)_